### PR TITLE
Update command definition and argument types to use typescript better.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *.rbxl
 *.rbxlx
 sourcemap.json
+*.tgz

--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
     "rojo",
     "console",
     "commands"
-  ]
+  ],
+  "devDependencies": {
+    "@rbxts/compiler-types": "^3.0.0-types.0",
+    "@rbxts/types": "^1.0.915"
+  }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,13 +1,43 @@
 /// <reference types="@rbxts/types" />
 
 declare namespace Konsole {
-	export interface Argument {
-		name?: string;
-		type?: string;
-		default?: unknown;
-		required?: boolean;
-		suggestions?: string[] | string;
-	}
+
+	type BooleanArgument = `${boolean}` | "yes" | "no" | "on" | "off" | "1" | "0";
+	
+	export type Argument =
+		| {
+				name?: string;
+				type: "string";
+				default?: string;
+				required?: boolean;
+				suggestions?: string[] | string;
+		}
+		| {
+				name?: string;
+				type: "number";
+				default?: number | `${number}`;
+				required?: boolean;
+				suggestions?: `${number}`[] | `${number}`;
+		}
+		| {
+				name?: string;
+				type: "boolean";
+				default?: boolean;
+				required?: boolean;
+				suggestions?: BooleanArgument[] | BooleanArgument;
+		}
+		| {
+				name?: string;
+				type: "player";
+				default?: never;
+				required?: boolean;
+		}
+		| {
+				name?: string;
+				type: "players";
+				default?: never;
+				required?: boolean;
+		};
 
 	export interface Outcome {
 		ok: boolean;
@@ -15,19 +45,31 @@ declare namespace Konsole {
 		message: string;
 	}
 
+	type ArgumentValue<T extends Argument> =
+		T["type"] extends "string" ? string :
+		T["type"] extends "number" ? number :
+		T["type"] extends "boolean" ? boolean :
+		T["type"] extends "player" ? Player :
+		T["type"] extends "players" ? Player[] :
+		never;
+
 	export type Run = (context: Context, ...args: unknown[]) => unknown;
 	export type RankResolver = (entity: unknown) => number | undefined;
 	export type ConfigOverrides = Record<string, Record<string, unknown>>;
 
-	export interface Definition {
+	type RunArgs<T extends readonly Argument[]> = {
+		[K in keyof T]: ArgumentValue<T[K]>;
+	};
+
+	export interface Definition<T extends readonly Argument[] = readonly Argument[]> {
 		name: string;
 		rank?: number | string;
 		aliases?: string[];
-		args?: Argument[];
+		args?: T;
 		description?: string;
 		cooldown?: number;
 		server?: string;
-		run?: Run;
+		run?: (context: Context, ...args: RunArgs<T>) => unknown;
 	}
 
 	export interface Command {
@@ -80,7 +122,9 @@ declare namespace Konsole {
 		Result: unknown;
 		bindRanks: (resolver?: RankResolver) => void;
 		create: (options?: ConfigOverrides) => Client;
-		define: (definition: Definition) => Command;
+		define: <const T extends readonly Argument[]>(
+			definition: Definition<T>,
+		) => Command;
 		getRank: (entity: unknown) => number;
 		host: (serverImplementations?: Record<string, Run>) => RemoteFunction | undefined;
 		implement: (name: string, callback: Run) => void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,7 +7,7 @@ declare namespace Konsole {
 	export type Argument =
 		| {
 				name?: string;
-				type: "string";
+				type?: "string";
 				default?: string;
 				required?: boolean;
 				suggestions?: string[] | string;
@@ -15,7 +15,7 @@ declare namespace Konsole {
 		| {
 				name?: string;
 				type: "number";
-				default?: number | `${number}`;
+				default?: number;
 				required?: boolean;
 				suggestions?: `${number}`[] | `${number}`;
 		}
@@ -46,12 +46,11 @@ declare namespace Konsole {
 	}
 
 	type ArgumentValue<T extends Argument> =
-		T["type"] extends "string" ? string :
 		T["type"] extends "number" ? number :
 		T["type"] extends "boolean" ? boolean :
 		T["type"] extends "player" ? Player :
 		T["type"] extends "players" ? Player[] :
-		never;
+		string;
 
 	export type Run = (context: Context, ...args: unknown[]) => unknown;
 	export type RankResolver = (entity: unknown) => number | undefined;


### PR DESCRIPTION
This PR updates the TypeScript declarations to make command definitions significantly more type-safe by leveraging TypeScript's inference system. Rather than treating command arguments as loosely typed values, the declaration file now models a relationship between the declared argument type and the value that's actually passed to the command callback.

The largest change was replacing the `Argument` interface with a discriminated union. Each supported type now has a unique definition, which allows TypeScript to validate properties that previously would accept any value. For example: numeric arguments only allow numeric defaults/suggestions, boolean arguments only allow boolean defaults/suggestions, and player/players arguments intentionally cannot define defaults since they are not meaningful for those types.

To support this, `Definition` is now generic over its argument list. An `ArgumentValue<T>` util maps each argument definition to its corresponding runtime value, while `RunArgs<T> transforms the entire argument array into a parameter list expected by the command callback. This allows `run` to be inferred directly from the command's argument definitions instead of always receiving `unknown[]`
For example, code like this is strictly typed:
(not like exactly, since I'm ignoring required properties, but you get it)
```typescript
Konsole.define({
    args: [{ type: "player" }, {type: "number" }, {type: "boolean"}],
    run: (ctx, plr, num, bool) => {
        // plr: Player
        // num: Number
        // bool: Boolean
    }
})
```