### PR TITLE
fix(typings): correct Client method emit; type the full API; infer implement args from define schemas

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -174,12 +174,28 @@ declare namespace Konsole {
 		readonly allows: (entity: RankEntity, required: number | RankName) => boolean;
 	}
 
+	/**
+	 * Shared by `Konsole.implement` and `Dispatch.implement` (the former just
+	 * delegates to the latter at runtime, so both must enforce the schema).
+	 * A branded `ServerName` binds the callback to its schema-inferred tuple;
+	 * plain strings fall through to the loose overload, which rejects branded
+	 * names (the intersection collapses to `never`) so an annotated callback
+	 * can't bypass its schema.
+	 */
+	interface Implement {
+		<A extends Args>(name: ServerName<A>, callback: (context: Context, ...args: NoInfer<A>) => unknown): void;
+		<N extends string, T extends Args = Args>(
+			name: N & ([N] extends [ServerName] ? never : unknown),
+			callback: (context: Context, ...args: T) => unknown,
+		): void;
+	}
+
 	export interface DispatchModule {
 		readonly remoteName: string;
 		readonly definitionsRemoteName: string;
 		readonly timeout: number;
 		readonly host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
-		readonly implement: (name: string, callback: Run<Array<any>>) => void;
+		readonly implement: Implement;
 		readonly execute: (text: string, entity?: RankEntity) => ExecuteResult;
 	}
 
@@ -429,19 +445,7 @@ declare namespace Konsole {
 		) => Command<RunArgs<T>, S>;
 		getRank: (entity: RankEntity) => number;
 		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
-		implement: {
-			<A extends Args>(name: ServerName<A>, callback: (context: Context, ...args: NoInfer<A>) => unknown): void;
-			/**
-			 * Escape hatch for names that never went through `define`. Branded
-			 * `ServerName`s are rejected here (the intersection collapses to
-			 * `never`), so a schema-typed name can't sneak past its schema by
-			 * annotating the callback differently.
-			 */
-			<N extends string, T extends Args = Args>(
-				name: N & ([N] extends [ServerName] ? never : unknown),
-				callback: (context: Context, ...args: T) => unknown,
-			): void;
-		};
+		implement: Implement;
 		run: (text: string) => ExecuteResult;
 		setRank: (userId: number | string, rank: number | RankName) => number;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -331,7 +331,7 @@ declare namespace Konsole {
 		readonly new: (options?: ConfigOverrides) => Client;
 	}
 
-	type RunArgs<T extends readonly Argument[]> = number extends T["length"]
+	type RunArgs<T extends readonly Argument[]> = number extends (T & { length: number })["length"]
 		? []
 		: { [K in keyof T]: ArgumentRuntimeValue<T[K]> };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -10,33 +10,35 @@ declare namespace Konsole {
 				type?: "string";
 				default?: string;
 				required?: boolean;
-				suggestions?: string[] | string;
+				suggestions?: readonly string[] | string;
 		}
 		| {
 				name?: string;
 				type: "number";
 				default?: number;
 				required?: boolean;
-				suggestions?: `${number}`[] | `${number}`;
+				suggestions?: readonly `${number}`[] | `${number}`;
 		}
 		| {
 				name?: string;
 				type: "boolean";
 				default?: boolean;
 				required?: boolean;
-				suggestions?: BooleanArgument[] | BooleanArgument;
+				suggestions?: readonly BooleanArgument[] | BooleanArgument;
 		}
 		| {
 				name?: string;
 				type: "player";
 				default?: never;
 				required?: boolean;
+				suggestions?: never;
 		}
 		| {
 				name?: string;
 				type: "players";
 				default?: never;
 				required?: boolean;
+				suggestions?: never;
 		};
 
 	export interface Outcome {
@@ -159,7 +161,7 @@ declare namespace Konsole {
 	export interface Rank {
 		id: number;
 		name: string;
-		aliases: string[];
+		aliases: readonly string[];
 		builtin?: boolean;
 	}
 
@@ -167,7 +169,7 @@ declare namespace Konsole {
 		readonly define: (id: number, name: string, aliases?: string[]) => Rank;
 		readonly resolve: (value: number | RankName) => number | undefined;
 		readonly label: (id: number) => string;
-		readonly list: () => Rank[];
+		readonly list: () => readonly Rank[];
 		readonly set: (userId: number | string, rank: number | RankName) => number;
 		readonly bind: (fn?: RankResolver) => void;
 		readonly get: (entity: RankEntity) => number;
@@ -203,7 +205,7 @@ declare namespace Konsole {
 		readonly define: (definition: Definition) => Command;
 		readonly find: (name: string) => Command | undefined;
 		readonly list: () => Command[];
-		readonly schemas: () => Record<string, Argument[]>;
+		readonly schemas: () => Record<string, readonly Argument[]>;
 		readonly suggestions: () => string[];
 		readonly watch: (fn?: () => void) => void;
 	}
@@ -314,7 +316,7 @@ declare namespace Konsole {
 			dimText: number;
 		};
 		input: {
-			activationKeys: Enum.KeyCode[];
+			activationKeys: readonly Enum.KeyCode[];
 			activationPriority: number;
 			forceclose: boolean;
 			command: string;
@@ -327,7 +329,7 @@ declare namespace Konsole {
 		};
 		commands: {
 			defaultLimit: number;
-			aliases: Record<string, string>;
+			aliases: Readonly<Record<string, string>>;
 		};
 	}
 
@@ -375,8 +377,8 @@ declare namespace Konsole {
 	export interface Command<A extends Args = Args, S extends string | undefined = string | undefined> {
 		name: string;
 		rank: number;
-		aliases: string[];
-		args: Argument[];
+		aliases: readonly string[];
+		args: readonly Argument[];
 		description: string;
 		cooldown: number;
 		server: S extends string ? ServerName<A> : undefined;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -124,6 +124,9 @@ declare namespace Konsole {
 
 	export type Args = ReadonlyArray<unknown>;
 
+	/** Blocks inference from this position so the branded name alone determines the tuple. */
+	type NoInfer<T> = [T][T extends unknown ? 0 : never];
+
 	/**
 	 * A server implementation name whose argument tuple was captured from the
 	 * `args` schema of the `define(...)` call that produced it. Passing one to
@@ -230,6 +233,7 @@ declare namespace Konsole {
 			historyChunkLines: number;
 			historyMaxHeight: number;
 			viewportTopInset: number;
+			hintHeight: number;
 			suggestionHeight: number;
 			suggestionGap: number;
 			suggestionRadius: number;
@@ -328,8 +332,14 @@ declare namespace Konsole {
 		readonly new: (options?: ConfigOverrides) => Client;
 	}
 
+	/**
+	 * When the schema is a fixed tuple (the usual inline `define` call), each
+	 * run argument gets its exact type. A widened `Argument[]` schema carries
+	 * no per-position info, so the args fall back to `any` — the runtime still
+	 * passes whatever was parsed.
+	 */
 	type RunArgs<T extends readonly Argument[]> = number extends (T & { length: number })["length"]
-		? []
+		? ReadonlyArray<any>
 		: { [K in keyof T]: ArgumentRuntimeValue<T[K]> };
 
 	export interface Definition<
@@ -374,6 +384,13 @@ declare namespace Konsole {
 	 * roblox-ts emits `client:show()` style calls for them.
 	 */
 	export interface Client {
+		/**
+		 * Nominal marker: only values returned by `create(...)`/`Render.new(...)`
+		 * are Clients. Without it the dot-call `Api` is structurally assignable
+		 * to `Client`, and roblox-ts would emit colon calls (`c:setEnabled(true)`)
+		 * against dot functions, shifting every argument by one at runtime.
+		 */
+		readonly _nominal_Client: unique symbol;
 		bindRun(callback: (text: string) => unknown): void;
 		clear(): void;
 		destroy(): void;
@@ -413,8 +430,17 @@ declare namespace Konsole {
 		getRank: (entity: RankEntity) => number;
 		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
 		implement: {
-			<A extends Args>(name: ServerName<A>, callback: (context: Context, ...args: A) => unknown): void;
-			<T extends Args = Args>(name: string, callback: (context: Context, ...args: T) => unknown): void;
+			<A extends Args>(name: ServerName<A>, callback: (context: Context, ...args: NoInfer<A>) => unknown): void;
+			/**
+			 * Escape hatch for names that never went through `define`. Branded
+			 * `ServerName`s are rejected here (the intersection collapses to
+			 * `never`), so a schema-typed name can't sneak past its schema by
+			 * annotating the callback differently.
+			 */
+			<N extends string, T extends Args = Args>(
+				name: N & ([N] extends [ServerName] ? never : unknown),
+				callback: (context: Context, ...args: T) => unknown,
+			): void;
 		};
 		run: (text: string) => ExecuteResult;
 		setRank: (userId: number | string, rank: number | RankName) => number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@
 declare namespace Konsole {
 
 	type BooleanArgument = `${boolean}` | "yes" | "no" | "on" | "off" | "1" | "0";
-	
+
 	export type Argument =
 		| {
 				name?: string;
@@ -45,6 +45,49 @@ declare namespace Konsole {
 		message: string;
 	}
 
+	export type ResultKind = "text" | "table" | "error" | "warn";
+
+	export interface RenderResult {
+		ok: boolean;
+		kind: ResultKind;
+		code?: string;
+		title: string;
+		message: string;
+		width: string;
+		columns?: string[];
+		rows: Array<Record<string, unknown>>;
+		hints?: string[];
+	}
+
+	export interface ResultOptions {
+		kind?: ResultKind;
+		title?: string;
+		message?: string;
+		width?: string;
+		columns?: string[];
+		rows?: Array<Record<string, unknown>>;
+		hints?: string[];
+	}
+
+	export interface ResultApi {
+		ok: (message?: unknown, options?: ResultOptions) => RenderResult;
+		err: (code?: unknown, message?: unknown, options?: ResultOptions) => RenderResult;
+		table: (
+			title?: unknown,
+			columns?: string[],
+			rows?: Array<Record<string, unknown>>,
+			options?: ResultOptions,
+		) => RenderResult;
+		status: (
+			title?: unknown,
+			rows?: Array<{ Field: unknown; Value: unknown }>,
+			options?: ResultOptions,
+		) => RenderResult;
+		from: (value: unknown) => RenderResult;
+	}
+
+	export type ExecuteResult = Outcome | RenderResult;
+
 	type ArgumentValue<T extends Argument> =
 		T["type"] extends "number" ? number :
 		T["type"] extends "boolean" ? boolean :
@@ -52,8 +95,6 @@ declare namespace Konsole {
 		T["type"] extends "players" ? Player[] :
 		string;
 
-	export type Run = (context: Context, ...args: unknown[]) => unknown;
-	export type RankResolver = (entity: unknown) => number | undefined;
 	export type PanelPosition =
 		| UDim2
 		| "br"
@@ -68,48 +109,319 @@ declare namespace Konsole {
 		| "bottom left"
 		| "bottom center"
 		| "top center";
-	export type ConfigOverrides = Record<string, Record<string, unknown>> & {
-		panel?: Record<string, unknown> & { position?: PanelPosition };
-	};
 
-	type RunArgs<T extends readonly Argument[]> = {
-		[K in keyof T]: ArgumentValue<T[K]>;
-	};
+	/**
+	 * What actually reaches the callback: `parse` skips an argument entirely
+	 * when it is `required: false`, has no `default`, and no token was typed —
+	 * so only that combination can be undefined. Defaults are inserted raw
+	 * (no conversion), and an absent `required` behaves like required.
+	 */
+	type ArgumentRuntimeValue<T extends Argument> = T extends { required: false }
+		? T extends { default: {} }
+			? ArgumentValue<T>
+			: ArgumentValue<T> | undefined
+		: ArgumentValue<T>;
 
-	export interface Definition<T extends readonly Argument[] = readonly Argument[]> {
+	export type Args = ReadonlyArray<unknown>;
+
+	/**
+	 * A server implementation name whose argument tuple was captured from the
+	 * `args` schema of the `define(...)` call that produced it. Passing one to
+	 * `implement(...)` types the callback parameters automatically.
+	 * At runtime this is a plain string.
+	 */
+	export type ServerName<A extends Args = Args> = string & { readonly __args: A };
+
+	export type Run<A extends Args = Args> = (context: Context, ...args: A) => unknown;
+
+	/** Built-in rank names ship with Konsole; custom ones can be defined via `Ranks.define`. */
+	export type RankName =
+		| "player"
+		| "helper"
+		| "trial"
+		| "lowmod"
+		| "moderator"
+		| "mod"
+		| "admin"
+		| "administrator"
+		| "creator"
+		| "owner"
+		| (string & {});
+
+	/** Anything rank lookups accept: a Player instance or a tonumber-able user id. */
+	export type RankEntity = Player | number | string | undefined;
+
+	export type RankResolver = (entity: RankEntity) => number | undefined;
+
+	export interface Rank {
+		id: number;
 		name: string;
-		rank?: number | string;
+		aliases: string[];
+		builtin?: boolean;
+	}
+
+	export interface RanksModule {
+		readonly define: (id: number, name: string, aliases?: string[]) => Rank;
+		readonly resolve: (value: number | RankName) => number | undefined;
+		readonly label: (id: number) => string;
+		readonly list: () => Rank[];
+		readonly set: (userId: number | string, rank: number | RankName) => number;
+		readonly bind: (fn?: RankResolver) => void;
+		readonly get: (entity: RankEntity) => number;
+		readonly allows: (entity: RankEntity, required: number | RankName) => boolean;
+	}
+
+	export interface DispatchModule {
+		readonly remoteName: string;
+		readonly definitionsRemoteName: string;
+		readonly timeout: number;
+		readonly host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
+		readonly implement: (name: string, callback: Run<Array<any>>) => void;
+		readonly execute: (text: string, entity?: RankEntity) => ExecuteResult;
+	}
+
+	export interface KommandModule {
+		readonly define: (definition: Definition) => Command;
+		readonly find: (name: string) => Command | undefined;
+		readonly list: () => Command[];
+		readonly schemas: () => Record<string, Argument[]>;
+		readonly suggestions: () => string[];
+		readonly watch: (fn?: () => void) => void;
+	}
+
+	/**
+	 * Converts one typed token. Returns `[true, value]` on success or
+	 * `[false, errorMessage]` on failure.
+	 */
+	export type Converter = (token: string, caller?: Player) => LuaTuple<[boolean, unknown]>;
+
+	export interface ArgumentsModule {
+		/** Built-in converter registry (`string`, `number`, `boolean`, `player`, `players`). */
+		readonly types: Record<string, Converter>;
+		readonly tokenize: (text?: string) => string[];
+		readonly split: (text?: string) => LuaTuple<[string | undefined, string[]]>;
+		readonly parse: (
+			argDefinitions: Argument[] | undefined,
+			tokens: string[],
+			caller?: Player,
+		) => LuaTuple<[boolean, unknown]>;
+	}
+
+	export interface ChatModule {
+		readonly bindKonsoleOpen: (callback: () => void) => () => void;
+		readonly unbindKonsoleOpen: () => void;
+	}
+
+	export interface ConfigGroups {
+		panel: {
+			position: PanelPosition;
+
+			width: number;
+			outputWidth: number;
+			wideWidth: number;
+			maxWidth: number;
+			collapsedWidth: number;
+			addChatCollapsedWidth: number;
+			addChatHoverWidth: number;
+			height: number;
+			inputHeight: number;
+			commandHeight: number;
+			historyLineHeight: number;
+			historyChunkLines: number;
+			historyMaxHeight: number;
+			stackHistoryMaxHeight: number;
+			viewportTopInset: number;
+			suggestionHeight: number;
+			suggestionGap: number;
+			suggestionRadius: number;
+			maxSuggestions: number;
+			hintHeight: number;
+			outputRadius: number;
+			bottomInset: number;
+			displayOrder: number;
+			shadowAssetId: string;
+			arrowAssetId: string;
+			addChatAssetId: string;
+			stackGap: number;
+		};
+		color: {
+			panel: Color3;
+			inputText: Color3;
+			promptText: Color3;
+			suggPanel: Color3;
+			suggText: Color3;
+			suggMatch: string;
+			suggSub: string;
+			hintGhost: Color3;
+			successRich: string;
+			successText: Color3;
+			errorRich: string;
+			errorText: Color3;
+			warnRich: string;
+			warnText: Color3;
+			mutedRich: string;
+			mutedText: Color3;
+			shadowColor: Color3;
+		};
+		motion: {
+			expandSmoothTime: number;
+			openSmoothTime: number;
+			openSlideOffset: number;
+			outputSmoothTime: number;
+			listSmoothTime: number;
+			textFadeTime: number;
+			textSlideOffset: number;
+			itemSlideSmoothTime: number;
+			collapseSmoothTime: number;
+			exitFadeTime: number;
+			hintFadeTime: number;
+			hintSlideTime: number;
+		};
+		layout: {
+			paddingX: number;
+			paddingY: number;
+			promptSize: number;
+			textSize: number;
+			suggTextSize: number;
+			hintTextSize: number;
+			hintOffsetY: number;
+			itemGap: number;
+		};
+		transparency: {
+			panel: number;
+			suggPanel: number;
+			shadow: number;
+			arrow: number;
+			text: number;
+			suggText: number;
+			dimText: number;
+		};
+		input: {
+			activationKeys: Enum.KeyCode[];
+			activationPriority: number;
+			forceclose: boolean;
+			command: string;
+			alias: string;
+		};
+		font: {
+			body: Enum.Font;
+			title: Enum.Font;
+			mono: Enum.Font;
+		};
+		commands: {
+			defaultLimit: number;
+			aliases: Record<string, string>;
+		};
+	}
+
+	export type ConfigOverrides = {
+		[K in keyof ConfigGroups]?: Partial<ConfigGroups[K]>;
+	};
+
+	export interface ConfigModule {
+		readonly groups: ConfigGroups;
+		readonly merge: (options?: ConfigOverrides) => ConfigGroups;
+	}
+
+	export interface RenderModule {
+		readonly Result: ResultApi;
+		readonly Formatter: unknown;
+		readonly Text: unknown;
+		readonly config: (options?: ConfigOverrides) => ConfigGroups;
+		readonly new: (options?: ConfigOverrides) => Client;
+	}
+
+	type RunArgs<T extends readonly Argument[]> = number extends T["length"]
+		? []
+		: { [K in keyof T]: ArgumentRuntimeValue<T[K]> };
+
+	export interface Definition<
+		T extends readonly Argument[] = readonly Argument[],
+		S extends string | undefined = string | undefined,
+	> {
+		name: string;
+		rank?: number | RankName;
 		aliases?: string[];
-		args?: T;
+		args?: T & readonly Argument[];
 		description?: string;
 		cooldown?: number;
-		server?: string;
+		server?: S;
 		run?: (context: Context, ...args: RunArgs<T>) => unknown;
 	}
 
-	export interface Command {
+	export interface Command<A extends Args = Args, S extends string | undefined = string | undefined> {
 		name: string;
 		rank: number;
 		aliases: string[];
 		args: Argument[];
 		description: string;
 		cooldown: number;
-		server?: string;
-		run?: Run;
+		server: S extends string ? ServerName<A> : undefined;
+		run?: Run<A>;
 	}
 
 	export interface Context {
 		entity?: Player;
 		kommand: Command;
 		text: string;
-		dispatch: unknown;
-		ranks: unknown;
-		run: (text: unknown) => unknown;
+		dispatch: DispatchModule;
+		ranks: RanksModule;
+		run: (text: string) => ExecuteResult;
 		reply: (message?: unknown) => Outcome;
 		err: (code?: unknown, message?: unknown) => Outcome;
 	}
 
+	/**
+	 * A console client returned by `Konsole.create(...)`. Its members are
+	 * colon-methods on the Luau side, so they are declared as methods here —
+	 * roblox-ts emits `client:show()` style calls for them.
+	 */
 	export interface Client {
+		bindRun(callback: (text: string) => unknown): void;
+		clear(): void;
+		destroy(): void;
+		focus(): void;
+		getCursorTarget(): Instance | undefined;
+		hide(): void;
+		setActivationKeys(keys: Enum.KeyCode[]): void;
+		setActivationUnlocksMouse(enabled: boolean): void;
+		setEnabled(enabled: boolean): void;
+		setMouseUnlockDriver(getFn?: () => boolean, setFn?: (enabled: boolean) => void): void;
+		setSchemas(map: Record<string, Argument[]>): void;
+		setSuggestions(list: string[]): void;
+		show(): void;
+		toggle(): void;
+	}
+
+	/**
+	 * The top-level API. Unlike `Client`, these are dot-functions on the Luau
+	 * side (they delegate to a lazily created default client), so they are
+	 * declared as function properties — roblox-ts emits `Konsole.show()`.
+	 */
+	export interface Api {
+		Arguments: ArgumentsModule;
+		Chat: ChatModule;
+		Config: ConfigModule;
+		Dispatch: DispatchModule;
+		Kommand: KommandModule;
+		Ranks: RanksModule;
+		Render: RenderModule;
+		Result: ResultApi;
+
+		bindRanks: (resolver?: RankResolver) => void;
+		create: (options?: ConfigOverrides) => Client;
+		define: <const T extends readonly Argument[] = readonly Argument[], S extends string | undefined = undefined>(
+			definition: Definition<T, S>,
+		) => Command<RunArgs<T>, S>;
+		getRank: (entity: RankEntity) => number;
+		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
+		implement: {
+			<A extends Args>(name: ServerName<A>, callback: (context: Context, ...args: A) => unknown): void;
+			<T extends Args = Args>(name: string, callback: (context: Context, ...args: T) => unknown): void;
+		};
+		run: (text: string) => ExecuteResult;
+		setRank: (userId: number | string, rank: number | RankName) => number;
+
 		bindRun: (callback: (text: string) => unknown) => void;
 		clear: () => void;
 		destroy: () => void;
@@ -120,31 +432,10 @@ declare namespace Konsole {
 		setActivationUnlocksMouse: (enabled: boolean) => void;
 		setEnabled: (enabled: boolean) => void;
 		setMouseUnlockDriver: (getFn?: () => boolean, setFn?: (enabled: boolean) => void) => void;
-		setSchemas: (map: Record<string, unknown>) => void;
+		setSchemas: (map: Record<string, Argument[]>) => void;
 		setSuggestions: (list: string[]) => void;
 		show: () => void;
 		toggle: () => void;
-	}
-
-	export interface Api extends Client {
-		Arguments: unknown;
-		Chat: unknown;
-		Config: unknown;
-		Dispatch: unknown;
-		Kommand: unknown;
-		Ranks: unknown;
-		Render: unknown;
-		Result: unknown;
-		bindRanks: (resolver?: RankResolver) => void;
-		create: (options?: ConfigOverrides) => Client;
-		define: <const T extends readonly Argument[]>(
-			definition: Definition<T>,
-		) => Command;
-		getRank: (entity: unknown) => number;
-		host: (serverImplementations?: Record<string, Run>) => RemoteFunction | undefined;
-		implement: (name: string, callback: Run) => void;
-		run: (text: string) => Outcome;
-		setRank: (userId: unknown, rank: number | string) => number;
 	}
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -229,15 +229,12 @@ declare namespace Konsole {
 			historyLineHeight: number;
 			historyChunkLines: number;
 			historyMaxHeight: number;
-			stackHistoryMaxHeight: number;
 			viewportTopInset: number;
 			suggestionHeight: number;
 			suggestionGap: number;
 			suggestionRadius: number;
 			maxSuggestions: number;
-			hintHeight: number;
 			outputRadius: number;
-			bottomInset: number;
 			displayOrder: number;
 			shadowAssetId: string;
 			arrowAssetId: string;


### PR DESCRIPTION
Types-only PR — no `.luau` changes and no runtime behavior changes. Rewrites `typings/index.d.ts` to match the Luau source and adds schema→callback inference for roblox-ts consumers.

## Fix

- **`Client` methods emitted as dot calls.** `Controller`'s members are colon-methods (`function Controller:show()`), but the typings declared them as arrow properties, so roblox-ts emitted `client.show()` — no `self` — and every method on a `Konsole.create()` client failed at runtime from TS. `Client` now uses method signatures, and the top-level `Api` no longer extends it, since the top-level functions are dot-style in `init.luau` and must keep emitting `Konsole.show()`.

## Additions (all backward compatible)

- **Schema→callback inference.** `define` captures the `args` schema and returns a `Command` whose `.server` is a branded string (`ServerName<A>`; plain string at runtime). Passing it to `implement` types the callback parameters automatically:

  ```ts
  const giveXp = Konsole.define({
      name: "giveXp",
      server: "giveXpServer",
      args: [
          { name: "target", type: "player", required: true },
          { name: "amount", type: "number", required: true },
      ],
  });

  Konsole.implement(giveXp.server, (context, player, amount) => {
      // player: Player, amount: number — no annotations or casts
  });
  ```

  `implement("name", cb)` with a plain string still works via overload.
- **Optional-arg truthfulness.** `required: false` with no `default` types as `| undefined`, matching `Arguments.parse` (which skips such args); args with a `default` stay non-optional (defaults are inserted unconverted), and an absent `required` behaves as required.
- **Full API surface typed from source:** `Result` (`ok`/`err`/`table`/`status`/`from` → `RenderResult` per `result.luau`), `Ranks` (incl. `RankEntity = Player | userId` and the built-in rank-name union), `Dispatch`, `Kommand`, `Arguments` (incl. the `Arguments.types` converter registry), `Chat`, `Render`, and every `Config` group so `create()` overrides autocomplete.
- **Editor completions inside `args`.** `define`'s type parameter now defaults to its constraint instead of `[]` — the empty-tuple default gave partially-typed arg objects a `never` contextual type, so editors showed no property completions.

## Verification

- Signatures traced module-by-module against `src/` (`dispatch`, `kommand`, `arguments`, `ranks`, `config`, `result`, `controller`).
- Typechecked in a roblox-ts project (TS 5.5), including tsserver completion probes and tuple-optionality assertions.
- `const` type parameters require TS ≥ 5.0 (roblox-ts already requires newer).

## Notes

- `host`'s implementations record uses `Run<Array<any>>` — `unknown[]` would reject typed callbacks under contravariance.
- `ExecuteResult` is `Outcome | RenderResult`; commands returning arbitrary tables still pass through at runtime.
- `Render.Formatter` / `Render.Text` are left `unknown` (UI internals).

## Disclosure

The main thing I wanted fixed was auto-typing for `implement` — in the upstream typings, `define` returns a plain `Command` with no arg capture, `implement` takes `(name: string, callback: Run)` where `Run` is `(context, ...unknown[])`, and all the sub-modules (`Ranks`, `Dispatch`, `Context.dispatch`, etc.) are typed `unknown`. So there was no inference at all: you'd define a command with a typed `args` schema and still have to manually annotate every callback parameter.

The upstream `Client` interface also has every member as an arrow property (dot-call style), but the Luau controller uses colon-methods, so all `Konsole.create()` client calls were emitting `client.show()` with no `self` and failing at runtime.

I didn't have time to audit the full typings rewrite myself, so I ran it through Claude (Fable 5), which traced each declaration against the Luau source module-by-module. I've reviewed the result and it's been tested in-game, but a second pair of eyes on the API surface wouldn't hurt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)