### PR TITLE
Change suggestions to readonly arrays in index.d.ts

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -10,33 +10,35 @@ declare namespace Konsole {
 				type?: "string";
 				default?: string;
 				required?: boolean;
-				suggestions?: string[] | string;
+				suggestions?: readonly string[] | string;
 		}
 		| {
 				name?: string;
 				type: "number";
 				default?: number;
 				required?: boolean;
-				suggestions?: `${number}`[] | `${number}`;
+				suggestions?: readonly `${number}`[] | `${number}`;
 		}
 		| {
 				name?: string;
 				type: "boolean";
 				default?: boolean;
 				required?: boolean;
-				suggestions?: BooleanArgument[] | BooleanArgument;
+				suggestions?: readonly BooleanArgument[] | BooleanArgument;
 		}
 		| {
 				name?: string;
 				type: "player";
 				default?: never;
 				required?: boolean;
+				suggestions?: never;
 		}
 		| {
 				name?: string;
 				type: "players";
 				default?: never;
 				required?: boolean;
+				suggestions?: never;
 		};
 
 	export interface Outcome {


### PR DESCRIPTION
This PR changed the suggestions field of Arguments to be readonly, which allows code such as this to work:
```ts
const foo = ["a", "b", "c"] as const;
Konsole.define({
	name: "test",
	args: [{ suggestions: foo }],
});
```
This PR also added a suggestions field of `never` to Player and Players argument types which allow indexing of arguments through context (`ctx.kommand.args[0].suggestions`). Previously, TypeScript didn't recognize the suggestions field because it may or may not have been applicable.