### PR TITLE
Fix calculation of top position for suggestions by moving rowHeight up a line

### DIFF
--- a/src/core/ui/elements/frontend/suggestions.luau
+++ b/src/core/ui/elements/frontend/suggestions.luau
@@ -250,8 +250,8 @@ function Suggestions.attach(Session)
 
 		local suggList = self.refs.suggList
 		if suggList:IsA("ScrollingFrame") then
-			local top = 2 + ((self.selectedSuggestion - 1) * rowHeight)
 			local rowHeight = self.config.panel.suggestionHeight
+			local top = 2 + ((self.selectedSuggestion - 1) * rowHeight)
 
 			local position = suggList.CanvasPosition.Y
 			local bottom = top + rowHeight


### PR DESCRIPTION
This PR moves the rowHeight variable above the top variable in the suggestions list so there won't be an error produced when navigating the suggestions list.