### PR TITLE
Pluggable codec for definitions replication

### DIFF
--- a/src/core/shared/dispatch/init.luau
+++ b/src/core/shared/dispatch/init.luau
@@ -31,6 +31,17 @@ local Dispatch = {
 	definitionsRemoteName = "KonsoleDefinitions",
 	remoteName = "Konsole",
 	timeout = 8,
+
+	-- swap these to route the definitions payload through your own network
+	-- layer (eg. a buffer-based serdes) instead of raw table replication
+	definitionsCodec = {
+		encode = function(list: { Definition }): any
+			return list
+		end,
+		decode = function(payload: any): { Definition }
+			return payload
+		end,
+	},
 }
 
 local implementations: { [string]: Run } = {}
@@ -205,10 +216,10 @@ function Dispatch.host(serverImplementations: { [string]: Run }?)
 	local definitionsBridge = ensureDefinitionsRemote()
 	if definitionsBridge then
 		definitionsBridge.OnServerEvent:Connect(function(player)
-			definitionsBridge:FireClient(player, currentDefinitions())
+			definitionsBridge:FireClient(player, Dispatch.definitionsCodec.encode(currentDefinitions()))
 		end)
 		imports.Kommand.watch(function()
-			definitionsBridge:FireAllClients(currentDefinitions())
+			definitionsBridge:FireAllClients(Dispatch.definitionsCodec.encode(currentDefinitions()))
 		end)
 	end
 
@@ -287,7 +298,8 @@ if imports.RunService:IsClient() then
 			return
 		end
 
-		bridge.OnClientEvent:Connect(function(list: any)
+		bridge.OnClientEvent:Connect(function(payload: any)
+			local list = Dispatch.definitionsCodec.decode(payload)
 			if type(list) ~= "table" then
 				return
 			end

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -110,11 +110,21 @@ declare namespace Konsole {
 		toggle: () => void;
 	}
 
+	export interface DispatchModule {
+		readonly remoteName: string;
+		readonly definitionsRemoteName: string;
+		readonly timeout: number;
+		definitionsCodec: {
+			encode: (list: Definition[]) => unknown;
+			decode: (payload: unknown) => Definition[];
+		};
+	}
+
 	export interface Api extends Client {
 		Arguments: unknown;
 		Chat: unknown;
 		Config: unknown;
-		Dispatch: unknown;
+		Dispatch: DispatchModule;
 		Kommand: unknown;
 		Ranks: unknown;
 		Render: unknown;


### PR DESCRIPTION
## Summary
- Definitions currently replicate to clients as a raw Lua table over `RemoteEvent`, which costs several KB per connect due to Roblox's default table serialization
- Adds `Dispatch.definitionsCodec` (`encode`/`decode`, identity by default) so a game can swap in its own network layer (eg. a buffer-based serdes) to shrink that payload, without changing how the remotes are wired up

## Test plan
- [ ] Default behavior unchanged when `definitionsCodec` is left untouched (identity encode/decode)
- [ ] Custom codec round-trips a definitions list correctly client-side