### PR TITLE
Pluggable definitions codec, custom argument types, builtin include/exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Konsole.focus()
 Konsole ships with a few small commands:
 
 - `cmds`: lists registered commands, rank, usage, and description
-- `clear` / `cls`: clears the active Konsole chat pane
+- `clear` / `cls` / `clr`: clears the active Konsole chat pane
 - `ranks`: lists known ranks
 - `bring`: brings target players to you
 - `tp`: teleports you to a target player
@@ -634,7 +634,7 @@ Argument shape:
 ```luau
 type Argument = {
 	name: string?,
-	type: string?,
+	type: ("string" | "number" | "boolean" | "player" | "players" | string)?,
 	default: any,
 	required: boolean?,
 	suggestions: ({ string } | string)?,

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The usual setup is:
 
 Inline `run` commands can run where they are registered. Server commands should usually use `server = "name"` with `Konsole.implement("name", callback)` or pass implementations into `Konsole.host(...)`.
 
+Command definitions replicate over a single packed `buffer`, not a raw table or JSON string — a fixed binary schema (no key names on the wire), string interning for repeated values (ranks, arg names, aliases), and a small built-in LZSS compression pass. All of this is native to Luau; there's no external dependency involved.
+
 ## Using It
 
 Server setup:
@@ -127,6 +129,15 @@ Konsole ships with a few small commands:
 - `kill`: kills a player
 
 The ban command is server-local. It blocks players for the lifetime of that server, not permanently across all servers. If you want persistent bans, store ban state in a DataStore and implement your own `banServer` / `unbanServer`.
+
+If you don't want the built-ins at all, call `Konsole.excludeBuiltins()` before anything else touches Konsole (before `host`/`create`/`define`/`run`):
+
+```luau
+Konsole.excludeBuiltins() -- drops all built-ins
+Konsole.excludeBuiltins({ "kick", "ban", "unban", "kill" }) -- drops just these
+```
+
+`cmds` and `clear` are never dropped, even with no args — they're the only way to see or recover from a stripped command list once everything else is gone.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -130,20 +130,15 @@ Konsole ships with a few small commands:
 
 The ban command is server-local. It blocks players for the lifetime of that server, not permanently across all servers. If you want persistent bans, store ban state in a DataStore and implement your own `banServer` / `unbanServer`.
 
-If you don't want the built-ins at all, call `Konsole.excludeBuiltins()` before anything else touches Konsole (before `host`/`create`/`define`/`run`):
+If you don't want some (or all) of the built-ins, call one of these before anything else touches Konsole (before `host`/`create`/`define`/`run`):
 
 ```luau
-Konsole.excludeBuiltins() -- drops all built-ins
-Konsole.excludeBuiltins({ "kick", "ban", "unban", "kill" }) -- drops just these
+Konsole.excludeBuiltins("kick", "ban", "unban", "kill") -- drops just these
+Konsole.excludeAllBuiltins() -- drops all built-ins
+Konsole.includeBuiltins("ban", "tp") -- keeps only ban and tp, drops the rest
 ```
 
-Or flip it around with `Konsole.includeBuiltins(...)` to keep only the names you list, dropping every other built-in:
-
-```luau
-Konsole.includeBuiltins("ban", "tp") -- keeps only ban and tp
-```
-
-`cmds` and `clear` are never dropped either way, even with no args to `excludeBuiltins()` — they're the only way to see or recover from a stripped command list once everything else is gone. `excludeBuiltins` and `includeBuiltins` can't be used together.
+`cmds` and `clear` are never dropped by any of these — they're the only way to see or recover from a stripped command list once everything else is gone. `excludeBuiltins`/`excludeAllBuiltins` and `includeBuiltins` can't be used together.
 
 ## Commands
 
@@ -573,7 +568,8 @@ Konsole.host(serverImplementations?)
 Konsole.define(definition)
 Konsole.implement(name, callback)
 Konsole.run(text)
-Konsole.excludeBuiltins(names?)
+Konsole.excludeBuiltins(...names)
+Konsole.excludeAllBuiltins()
 Konsole.includeBuiltins(...names)
 Konsole.registerType(name, converter)
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,31 @@ For `player`, the token must resolve to exactly one player. For `players`, it ca
 
 Konsole also uses argument metadata for the UI. When you type a command with args, it shows argument chips. Fixed-token args like `number` and `boolean` jump to the next chip when you press space. Bad argument types turn red while typing.
 
+### Custom Argument Types
+
+Register your own type with `Konsole.registerType(name, converter)`. The converter gets the raw token (and the calling player, if any) and returns `ok, valueOrErrorMessage` — same shape as the built-ins:
+
+```luau
+Konsole.registerType("team", function(token: string, caller: Player?): (boolean, any)
+	local team = game:GetService("Teams"):FindFirstChild(token)
+	if not team then
+		return false, `no team named "{token}"`
+	end
+	return true, team
+end)
+
+Konsole.define({
+	name = "setteam",
+	args = {
+		{ name = "player", type = "player", required = true },
+		{ name = "team", type = "team", required = true },
+	},
+	server = "setteam",
+})
+```
+
+Built-in type names (`string`, `number`, `boolean`, `player`, `players`) can't be overwritten. Register custom types before any command that uses them is defined.
+
 ## Suggestions
 
 Suggestions come from command names, aliases, and argument providers.
@@ -550,6 +575,7 @@ Konsole.implement(name, callback)
 Konsole.run(text)
 Konsole.excludeBuiltins(names?)
 Konsole.includeBuiltins(...names)
+Konsole.registerType(name, converter)
 
 Konsole.setRank(userId, rank)
 Konsole.getRank(entity)

--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Konsole.host(serverImplementations?)
 Konsole.define(definition)
 Konsole.implement(name, callback)
 Konsole.run(text)
+Konsole.excludeBuiltins(names?)
 
 Konsole.setRank(userId, rank)
 Konsole.getRank(entity)

--- a/README.md
+++ b/README.md
@@ -137,7 +137,13 @@ Konsole.excludeBuiltins() -- drops all built-ins
 Konsole.excludeBuiltins({ "kick", "ban", "unban", "kill" }) -- drops just these
 ```
 
-`cmds` and `clear` are never dropped, even with no args — they're the only way to see or recover from a stripped command list once everything else is gone.
+Or flip it around with `Konsole.includeBuiltins(...)` to keep only the names you list, dropping every other built-in:
+
+```luau
+Konsole.includeBuiltins("ban", "tp") -- keeps only ban and tp
+```
+
+`cmds` and `clear` are never dropped either way, even with no args to `excludeBuiltins()` — they're the only way to see or recover from a stripped command list once everything else is gone. `excludeBuiltins` and `includeBuiltins` can't be used together.
 
 ## Commands
 
@@ -543,6 +549,7 @@ Konsole.define(definition)
 Konsole.implement(name, callback)
 Konsole.run(text)
 Konsole.excludeBuiltins(names?)
+Konsole.includeBuiltins(...names)
 
 Konsole.setRank(userId, rank)
 Konsole.getRank(entity)

--- a/src/cmds/10/clear.luau
+++ b/src/cmds/10/clear.luau
@@ -7,7 +7,7 @@
 return table.freeze({
 	name = "clear",
 	rank = 0,
-	aliases = { "cls" },
+	aliases = { "cls", "clr" },
 	description = "Clears the console output.",
 	run = function(context)
 		return context.reply("cleared")

--- a/src/cmds/init.luau
+++ b/src/cmds/init.luau
@@ -52,9 +52,16 @@ local Cmds = {
 	server = imports.server :: { [string]: Run },
 }
 
-function Cmds.register(kommand: any)
+-- cmds/clear are the only ways to see/recover the command list once
+-- built-ins are stripped, so they're never excludable
+local mandatory = { cmds = true, clear = true }
+
+function Cmds.register(kommand: any, excluded: { [string]: boolean }?)
 	for index, definition in Cmds.definitions do
 		assert(type(definition.name) == "string", `invalid built-in command at index {index}`)
+		if excluded and not mandatory[definition.name] and (excluded.all or excluded[definition.name]) then
+			continue
+		end
 		kommand.define(definition)
 	end
 end

--- a/src/core/shared/dispatch/init.luau
+++ b/src/core/shared/dispatch/init.luau
@@ -26,6 +26,7 @@ export type Command = Types.Command
 export type Context = Types.Context
 export type Outcome = Types.Outcome
 export type Run = Types.Run
+type Argument = Types.Argument
 
 local Dispatch = {
 	definitionsRemoteName = "KonsoleDefinitions",
@@ -161,9 +162,404 @@ end
 	@description fns can't cross a Remote so a kommand is stripped down to its
  	plain-data schema before being sent to clients (server stays authoritative of course
 	on `run` clients only need enough to route the call back via `server`)
-	
+
 	@time June 4, 2026 11:52 AM
 ]]
+
+--[[
+	@description binary codec for the definitions list -- fixed field order so
+	no key names ever hit the wire (unlike JSON), string.pack/unpack are
+	built into Luau so this needs nothing outside the engine. An empty string
+	is used as the "absent" sentinel for optional string fields (name/
+	description/server) rather than a separate tag byte, since none of those
+	are meaningfully used as an actual empty string vs unset.
+]]
+--[[
+	@description names, rank strings, and suggestion strings repeat a lot across
+	a real command set (e.g. rank = "admin" on half the commands, arg name
+	"player"/"target" reused everywhere) -- pooling them once and referencing by
+	index instead of re-sending the literal text each time cuts real bytes.
+	Descriptions are intentionally NOT pooled: they're long, mostly-unique
+	sentences, so a pool entry would cost more than just inlining them.
+]]
+type Pool = { list: { string }, index: { [string]: number } }
+
+local function internString(pool: Pool, value: string?): ()
+	if value and not pool.index[value] then
+		table.insert(pool.list, value)
+		pool.index[value] = #pool.list
+	end
+end
+
+local function buildPool(list: { Definition }): Pool
+	local pool: Pool = { list = {}, index = {} }
+
+	for _, definition in list do
+		if type(definition.rank) == "string" then
+			internString(pool, definition.rank :: string)
+		end
+		internString(pool, definition.server)
+
+		if definition.aliases then
+			for _, alias in definition.aliases do
+				internString(pool, alias)
+			end
+		end
+
+		if definition.args then
+			for _, arg in definition.args do
+				internString(pool, arg.name)
+				if type(arg.suggestions) == "string" then
+					internString(pool, arg.suggestions :: string)
+				elseif type(arg.suggestions) == "table" then
+					for _, s in arg.suggestions :: { string } do
+						internString(pool, s)
+					end
+				end
+			end
+		end
+	end
+
+	return pool
+end
+
+local function packPool(pool: Pool): string
+	local out = string.pack("<H", #pool.list)
+	for _, s in pool.list do
+		out ..= string.pack("<s1", s)
+	end
+	return out
+end
+
+local function unpackPool(data: string, pos: number): ({ string }, number)
+	local count
+	count, pos = string.unpack("<H", data, pos)
+	local list = {}
+	for i = 1, count do
+		list[i], pos = string.unpack("<s1", data, pos)
+	end
+	return list, pos
+end
+
+local function packStringArray(list: { string }?, pool: Pool): string
+	local out = string.pack("<B", list and #list or 0)
+	if list then
+		for _, s in list do
+			out ..= string.pack("<H", pool.index[s])
+		end
+	end
+	return out
+end
+
+local function unpackStringArray(data: string, pos: number, pool: { string }): ({ string }, number)
+	local count
+	count, pos = string.unpack("<B", data, pos)
+	local out = {}
+	for i = 1, count do
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		out[i] = pool[idx]
+	end
+	return out, pos
+end
+
+local function packRank(rank: (number | string)?, pool: Pool): string
+	if type(rank) == "number" then
+		return string.pack("<Bd", 1, rank)
+	elseif type(rank) == "string" then
+		return string.pack("<BH", 2, pool.index[rank])
+	end
+	return string.pack("<B", 0)
+end
+
+local function unpackRank(data: string, pos: number, pool: { string }): (any, number)
+	local tag
+	tag, pos = string.unpack("<B", data, pos)
+	if tag == 1 then
+		return string.unpack("<d", data, pos)
+	elseif tag == 2 then
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		return pool[idx], pos
+	end
+	return nil, pos
+end
+
+-- shared by Argument.default (string | number | boolean | nil); default values
+-- are typically unique per-argument so they're inlined, not pooled
+local function packAny(value: any): string
+	if type(value) == "string" then
+		return string.pack("<B", 1) .. string.pack("<s1", value)
+	elseif type(value) == "number" then
+		return string.pack("<Bd", 2, value)
+	elseif type(value) == "boolean" then
+		return string.pack("<BB", 3, if value then 1 else 0)
+	end
+	return string.pack("<B", 0)
+end
+
+local function unpackAny(data: string, pos: number): (any, number)
+	local tag
+	tag, pos = string.unpack("<B", data, pos)
+	if tag == 1 then
+		return string.unpack("<s1", data, pos)
+	elseif tag == 2 then
+		return string.unpack("<d", data, pos)
+	elseif tag == 3 then
+		local n
+		n, pos = string.unpack("<B", data, pos)
+		return n == 1, pos
+	end
+	return nil, pos
+end
+
+local argumentTypeTags: { [string]: number } = { string = 1, number = 2, boolean = 3, player = 4, players = 5 }
+local argumentTypeNames: { [number]: string } = { "string", "number", "boolean", "player", "players" }
+
+local function packArgument(arg: Argument, pool: Pool): string
+	local typeTag = (arg.type and argumentTypeTags[arg.type]) or 0
+	local flags = bit32.bor(bit32.lshift(typeTag, 1), if arg.required then 1 else 0)
+	local nameIdx = if arg.name then pool.index[arg.name] else 0
+	local out = string.pack("<H", nameIdx) .. string.pack("<B", flags) .. packAny(arg.default)
+
+	if type(arg.suggestions) == "table" then
+		out ..= string.pack("<B", 2) .. packStringArray(arg.suggestions :: { string }, pool)
+	elseif type(arg.suggestions) == "string" then
+		out ..= string.pack("<BH", 1, pool.index[arg.suggestions])
+	else
+		out ..= string.pack("<B", 0)
+	end
+
+	return out
+end
+
+local function unpackArgument(data: string, pos: number, pool: { string }): (Argument, number)
+	local nameIdx, flags, suggestionsTag: number
+	nameIdx, pos = string.unpack("<H", data, pos)
+	flags, pos = string.unpack("<B", data, pos)
+	local argType = bit32.rshift(flags, 1)
+	local required = bit32.band(flags, 1)
+	local default
+	default, pos = unpackAny(data, pos)
+	suggestionsTag, pos = string.unpack("<B", data, pos)
+
+	local suggestions: any = nil
+	if suggestionsTag == 2 then
+		suggestions, pos = unpackStringArray(data, pos, pool)
+	elseif suggestionsTag == 1 then
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		suggestions = pool[idx]
+	end
+
+	return {
+		name = if nameIdx ~= 0 then pool[nameIdx] else nil,
+		type = argumentTypeNames[argType],
+		default = default,
+		required = required == 1,
+		suggestions = suggestions,
+	}, pos
+end
+
+local function packDefinition(definition: Definition, pool: Pool): string
+	local out = string.pack("<s1", definition.name)
+		.. packRank(definition.rank, pool)
+		.. packStringArray(definition.aliases, pool)
+
+	local args = definition.args
+	out ..= string.pack("<B", args and #args or 0)
+	if args then
+		for _, arg in args do
+			out ..= packArgument(arg, pool)
+		end
+	end
+
+	out ..= string.pack("<s1", definition.description or "")
+
+	if definition.cooldown and definition.cooldown > 0 then
+		out ..= string.pack("<Bf", 1, definition.cooldown)
+	else
+		out ..= string.pack("<B", 0)
+	end
+
+	if definition.server then
+		out ..= string.pack("<BH", 1, pool.index[definition.server])
+	else
+		out ..= string.pack("<B", 0)
+	end
+
+	return out
+end
+
+local function unpackDefinition(data: string, pos: number, pool: { string }): (Definition, number)
+	local name: string
+	local argCount: number
+	local description: string
+	local cooldown: number
+	name, pos = string.unpack("<s1", data, pos)
+
+	local rank
+	rank, pos = unpackRank(data, pos, pool)
+
+	local aliases
+	aliases, pos = unpackStringArray(data, pos, pool)
+
+	argCount, pos = string.unpack("<B", data, pos)
+	local args = {}
+	for i = 1, argCount do
+		args[i], pos = unpackArgument(data, pos, pool)
+	end
+
+	description, pos = string.unpack("<s1", data, pos)
+
+	local cooldownTag: number
+	cooldownTag, pos = string.unpack("<B", data, pos)
+	if cooldownTag == 1 then
+		cooldown, pos = string.unpack("<f", data, pos)
+	else
+		cooldown = 0
+	end
+
+	local serverTag: number
+	serverTag, pos = string.unpack("<B", data, pos)
+	local serverName: string?
+	if serverTag == 1 then
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		serverName = pool[idx]
+	end
+
+	return {
+		name = name,
+		rank = rank,
+		aliases = aliases,
+		args = args,
+		description = if description ~= "" then description else nil,
+		cooldown = cooldown,
+		server = serverName,
+	}, pos
+end
+
+--[[
+	@description a small dependency-free LZSS pass over the final packed bytes.
+	Matches minMatch=4+ so a match (3-byte token, amortized ~3.125 with its
+	control-bit) never costs more than the literals it replaces. Repeated
+	byte sequences show up a lot here (e.g. many arguments share the same
+	trailing type/flags/default/suggestions tag bytes), so this squeezes
+	real repetition string.pack's fixed schema can't see on its own.
+]]
+local lzWindow = 4096
+local lzMinMatch = 4
+local lzMaxMatch = 255
+
+local function lzCompress(data: string): string
+	local n = #data
+	local out = {}
+	local controlIndex = 0
+	local controlByte = 0
+	local bitCount = 0
+
+	local i = 1
+	while i <= n do
+		if bitCount == 0 then
+			table.insert(out, "\0")
+			controlIndex = #out
+			controlByte = 0
+		end
+
+		local bestLen = 0
+		local bestOffset = 0
+		local limit = math.min(lzMaxMatch, n - i + 1)
+		if limit >= lzMinMatch then
+			local searchStart = math.max(1, i - lzWindow)
+			for j = i - 1, searchStart, -1 do
+				local len = 0
+				while len < limit and string.byte(data, j + len) == string.byte(data, i + len) do
+					len += 1
+				end
+				if len > bestLen then
+					bestLen = len
+					bestOffset = i - j
+					if len == limit then
+						break
+					end
+				end
+			end
+		end
+
+		if bestLen >= lzMinMatch then
+			table.insert(out, string.pack("<HB", bestOffset, bestLen))
+			i += bestLen
+		else
+			controlByte = bit32.bor(controlByte, bit32.lshift(1, bitCount))
+			table.insert(out, string.char(string.byte(data, i)))
+			i += 1
+		end
+
+		bitCount += 1
+		out[controlIndex] = string.char(controlByte)
+		if bitCount == 8 then
+			bitCount = 0
+		end
+	end
+
+	return table.concat(out)
+end
+
+local function lzDecompress(data: string): string
+	local n = #data
+	local outChars = {}
+	local outLen = 0
+	local pos = 1
+
+	while pos <= n do
+		local control: number
+		control, pos = string.unpack("<B", data, pos)
+		for bitIndex = 0, 7 do
+			if pos > n then
+				break
+			end
+			if bit32.band(bit32.rshift(control, bitIndex), 1) == 1 then
+				local byte
+				byte, pos = string.unpack("<B", data, pos)
+				outLen += 1
+				outChars[outLen] = string.char(byte)
+			else
+				local offset, len
+				offset, len, pos = string.unpack("<HB", data, pos)
+				local start = outLen - offset
+				for k = 1, len do
+					outLen += 1
+					outChars[outLen] = outChars[start + k]
+				end
+			end
+		end
+	end
+
+	return table.concat(outChars, "", 1, outLen)
+end
+
+local function encodeDefinitions(list: { Definition }): buffer
+	local pool = buildPool(list)
+	local out = packPool(pool) .. string.pack("<H", #list)
+	for _, definition in list do
+		out ..= packDefinition(definition, pool)
+	end
+	return buffer.fromstring(lzCompress(out))
+end
+
+local function decodeDefinitions(payload: buffer): { Definition }
+	local data = lzDecompress(buffer.tostring(payload))
+	local pool, pos = unpackPool(data, 1)
+	local count
+	count, pos = string.unpack("<H", data, pos)
+	local out = {}
+	for i = 1, count do
+		out[i], pos = unpackDefinition(data, pos, pool)
+	end
+	return out
+end
+
 local function currentDefinitions(): { Definition }
 	local out: { Definition } = {}
 	for _, kommand in imports.Kommand.list() do
@@ -205,10 +601,10 @@ function Dispatch.host(serverImplementations: { [string]: Run }?)
 	local definitionsBridge = ensureDefinitionsRemote()
 	if definitionsBridge then
 		definitionsBridge.OnServerEvent:Connect(function(player)
-			definitionsBridge:FireClient(player, currentDefinitions())
+			definitionsBridge:FireClient(player, encodeDefinitions(currentDefinitions()))
 		end)
 		imports.Kommand.watch(function()
-			definitionsBridge:FireAllClients(currentDefinitions())
+			definitionsBridge:FireAllClients(encodeDefinitions(currentDefinitions()))
 		end)
 	end
 
@@ -287,11 +683,12 @@ if imports.RunService:IsClient() then
 			return
 		end
 
-		bridge.OnClientEvent:Connect(function(list: any)
-			if type(list) ~= "table" then
+		bridge.OnClientEvent:Connect(function(payload: any)
+			if typeof(payload) ~= "buffer" then
 				return
 			end
-			for _, definition in list :: { Definition } do
+			local list = decodeDefinitions(payload)
+			for _, definition in list do
 				imports.Kommand.define(definition)
 			end
 		end)

--- a/src/core/shared/kommand/arguments.luau
+++ b/src/core/shared/kommand/arguments.luau
@@ -138,6 +138,23 @@ Arguments.types = {
 	end,
 } :: Converters
 
+local builtinTypeNames = { string = true, number = true, boolean = true, player = true, players = true }
+
+--[[
+	@description register a custom argument type so `args = { { type = name } }`
+	can use it like any built-in. converter receives the raw token + the caller
+	and returns (ok, valueOrErrorMessage), same shape as the built-ins above.
+	Built-in type names can't be overwritten.
+	@time July 28, 2026
+]]
+function Arguments.register(name: string, converter: Converter): ()
+	local typeName = string.lower(tostring(name))
+	assert(typeName ~= "", "argument type name can't be empty")
+	assert(not builtinTypeNames[typeName], `"{typeName}" is a built-in argument type and can't be overwritten`)
+	assert(type(converter) == "function", "argument type converter must be a function")
+	Arguments.types[typeName] = converter
+end
+
 function Arguments.parse(argDefinitions: { Argument }?, tokens: { string }, caller: Caller): (boolean, any)
 	local values = {}
 	local definitions: { Argument } = if type(argDefinitions) == "table" then argDefinitions else {}

--- a/src/core/shared/kommand/types.luau
+++ b/src/core/shared/kommand/types.luau
@@ -12,9 +12,11 @@ export type Converter = (token: string, caller: Caller) -> (boolean, any)
 
 export type Converters = { [string]: Converter }
 
+export type BuiltinArgumentType = "string" | "number" | "boolean" | "player" | "players"
+
 export type Argument = {
 	name: string?,
-	type: string?,
+	type: (BuiltinArgumentType | string)?,
 	default: any,
 	required: boolean?,
 	suggestions: ({ string } | string)?,

--- a/src/init.luau
+++ b/src/init.luau
@@ -65,25 +65,32 @@ local function registerBuiltins(): ()
 end
 
 --[[
-	@description opt out of Konsole's built-in commands (bring/clear/close/ranks/
+	@description opt out of specific built-in commands (bring/clear/close/ranks/
 	unban/cmds/kick/kill/ban/tp) so they don't register or replicate at all.
-	Call with no args (or nil) to drop all of them, or a list of names to drop
-	just those. Must be called before Konsole.create/host/run/define first runs.
+	Must be called before Konsole.create/host/run/define first runs.
+	@see Konsole.excludeAllBuiltins
 	@time July 28, 2026
 ]]
-function Konsole.excludeBuiltins(names: { BuiltinName }?): ()
+function Konsole.excludeBuiltins(...: BuiltinName): ()
 	assert(not registered, "Konsole.excludeBuiltins must be called before Konsole is used")
 	assert(builtinsIncluded == nil, "Konsole.excludeBuiltins cannot be used together with Konsole.includeBuiltins")
-	if names == nil then
-		builtinsExcluded = { all = true }
-		return
-	end
 
 	local set = {}
-	for _, name in names do
+	for _, name in { ... } do
 		set[name] = true
 	end
 	builtinsExcluded = set
+end
+
+--[[
+	@description drops every built-in command. Must be called before Konsole
+	is used.
+	@time July 28, 2026
+]]
+function Konsole.excludeAllBuiltins(): ()
+	assert(not registered, "Konsole.excludeAllBuiltins must be called before Konsole is used")
+	assert(builtinsIncluded == nil, "Konsole.excludeAllBuiltins cannot be used together with Konsole.includeBuiltins")
+	builtinsExcluded = { all = true }
 end
 
 --[[

--- a/src/init.luau
+++ b/src/init.luau
@@ -133,6 +133,16 @@ local function callDefault(method: string, ...: any): ...any
 	return client[method](client, ...)
 end
 
+--[[
+	@description register a custom argument type usable in `args = { { type = name } }`,
+	e.g. Konsole.registerType("team", function(token, caller) ... end).
+	Converter shape matches the built-ins: (token, caller) -> (ok, valueOrError).
+	@time July 28, 2026
+]]
+function Konsole.registerType(name: string, converter: (token: string, caller: Player?) -> (boolean, any)): ()
+	imports.core.shared.arguments.register(name, converter)
+end
+
 function Konsole.create(options: any?): Client
 	registerBuiltins()
 	return imports.core.ui.render.new(options)

--- a/src/init.luau
+++ b/src/init.luau
@@ -43,13 +43,25 @@ local Konsole = {
 local registered = false
 local defaultClient: Client = nil
 local builtinsExcluded: { [string]: boolean }? = nil
+local builtinsIncluded: { [string]: boolean }? = nil
 
 local function registerBuiltins(): ()
 	if registered then
 		return
 	end
 	registered = true
-	imports.cmds.register(imports.core.shared.kommand, builtinsExcluded)
+
+	local excluded = builtinsExcluded
+	if builtinsIncluded then
+		excluded = {}
+		for _, definition in imports.cmds.definitions do
+			if not builtinsIncluded[definition.name] then
+				excluded[definition.name] = true
+			end
+		end
+	end
+
+	imports.cmds.register(imports.core.shared.kommand, excluded)
 end
 
 --[[
@@ -61,6 +73,7 @@ end
 ]]
 function Konsole.excludeBuiltins(names: { BuiltinName }?): ()
 	assert(not registered, "Konsole.excludeBuiltins must be called before Konsole is used")
+	assert(builtinsIncluded == nil, "Konsole.excludeBuiltins cannot be used together with Konsole.includeBuiltins")
 	if names == nil then
 		builtinsExcluded = { all = true }
 		return
@@ -71,6 +84,23 @@ function Konsole.excludeBuiltins(names: { BuiltinName }?): ()
 		set[name] = true
 	end
 	builtinsExcluded = set
+end
+
+--[[
+	@description opposite of excludeBuiltins: drops every built-in EXCEPT the
+	names passed, e.g. Konsole.includeBuiltins("ban", "tp") keeps only those two.
+	cmds/clear stay registered regardless. Must be called before Konsole is used.
+	@time July 28, 2026
+]]
+function Konsole.includeBuiltins(...: BuiltinName): ()
+	assert(not registered, "Konsole.includeBuiltins must be called before Konsole is used")
+	assert(builtinsExcluded == nil, "Konsole.includeBuiltins cannot be used together with Konsole.excludeBuiltins")
+
+	local set = {}
+	for _, name in { ... } do
+		set[name] = true
+	end
+	builtinsIncluded = set
 end
 
 local function getDefaultClient(): Client

--- a/src/init.luau
+++ b/src/init.luau
@@ -40,13 +40,35 @@ local Konsole = {
 
 local registered = false
 local defaultClient: Client = nil
+local builtinsExcluded: { [string]: boolean }? = nil
 
 local function registerBuiltins(): ()
 	if registered then
 		return
 	end
 	registered = true
-	imports.cmds.register(imports.core.shared.kommand)
+	imports.cmds.register(imports.core.shared.kommand, builtinsExcluded)
+end
+
+--[[
+	@description opt out of Konsole's built-in commands (bring/clear/close/ranks/
+	unban/cmds/kick/kill/ban/tp) so they don't register or replicate at all.
+	Call with no args (or nil) to drop all of them, or a list of names to drop
+	just those. Must be called before Konsole.create/host/run/define first runs.
+	@time July 28, 2026
+]]
+function Konsole.excludeBuiltins(names: { string }?): ()
+	assert(not registered, "Konsole.excludeBuiltins must be called before Konsole is used")
+	if names == nil then
+		builtinsExcluded = { all = true }
+		return
+	end
+
+	local set = {}
+	for _, name in names do
+		set[name] = true
+	end
+	builtinsExcluded = set
 end
 
 local function getDefaultClient(): Client

--- a/src/init.luau
+++ b/src/init.luau
@@ -25,6 +25,8 @@ export type Run = Types.Run
 
 type Client = any
 
+export type BuiltinName = "bring" | "clear" | "close" | "ranks" | "unban" | "cmds" | "kick" | "kill" | "ban" | "tp"
+
 local Konsole = {
 	Arguments = imports.core.shared.arguments,
 	Dispatch = imports.core.shared.dispatch,
@@ -57,7 +59,7 @@ end
 	just those. Must be called before Konsole.create/host/run/define first runs.
 	@time July 28, 2026
 ]]
-function Konsole.excludeBuiltins(names: { string }?): ()
+function Konsole.excludeBuiltins(names: { BuiltinName }?): ()
 	assert(not registered, "Konsole.excludeBuiltins must be called before Konsole is used")
 	if names == nil then
 		builtinsExcluded = { all = true }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -39,6 +39,13 @@ declare namespace Konsole {
 				type: "players";
 				default?: never;
 				required?: boolean;
+		}
+		| {
+				name?: string;
+				type: string & {};
+				default?: unknown;
+				required?: boolean;
+				suggestions?: string[] | string;
 		};
 
 	export interface Outcome {
@@ -433,6 +440,7 @@ declare namespace Konsole {
 		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
 		implement: Implement;
 		includeBuiltins: (...names: Array<BuiltinName>) => void;
+		registerType: (name: string, converter: Converter) => void;
 		run: (text: string) => ExecuteResult;
 		setRank: (userId: number | string, rank: number | RankName) => number;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -435,7 +435,8 @@ declare namespace Konsole {
 		define: <const T extends readonly Argument[] = readonly Argument[], S extends string | undefined = undefined>(
 			definition: Definition<T, S>,
 		) => Command<RunArgs<T>, S>;
-		excludeBuiltins: (names?: Array<BuiltinName>) => void;
+		excludeAllBuiltins: () => void;
+		excludeBuiltins: (...names: Array<BuiltinName>) => void;
 		getRank: (entity: RankEntity) => number;
 		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
 		implement: Implement;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@
 declare namespace Konsole {
 
 	type BooleanArgument = `${boolean}` | "yes" | "no" | "on" | "off" | "1" | "0";
-	
+
 	export type Argument =
 		| {
 				name?: string;
@@ -45,6 +45,49 @@ declare namespace Konsole {
 		message: string;
 	}
 
+	export type ResultKind = "text" | "table" | "error" | "warn";
+
+	export interface RenderResult {
+		ok: boolean;
+		kind: ResultKind;
+		code?: string;
+		title: string;
+		message: string;
+		width: string;
+		columns?: string[];
+		rows: Array<Record<string, unknown>>;
+		hints?: string[];
+	}
+
+	export interface ResultOptions {
+		kind?: ResultKind;
+		title?: string;
+		message?: string;
+		width?: string;
+		columns?: string[];
+		rows?: Array<Record<string, unknown>>;
+		hints?: string[];
+	}
+
+	export interface ResultApi {
+		ok: (message?: unknown, options?: ResultOptions) => RenderResult;
+		err: (code?: unknown, message?: unknown, options?: ResultOptions) => RenderResult;
+		table: (
+			title?: unknown,
+			columns?: string[],
+			rows?: Array<Record<string, unknown>>,
+			options?: ResultOptions,
+		) => RenderResult;
+		status: (
+			title?: unknown,
+			rows?: Array<{ Field: unknown; Value: unknown }>,
+			options?: ResultOptions,
+		) => RenderResult;
+		from: (value: unknown) => RenderResult;
+	}
+
+	export type ExecuteResult = Outcome | RenderResult;
+
 	type ArgumentValue<T extends Argument> =
 		T["type"] extends "number" ? number :
 		T["type"] extends "boolean" ? boolean :
@@ -52,48 +95,344 @@ declare namespace Konsole {
 		T["type"] extends "players" ? Player[] :
 		string;
 
-	export type Run = (context: Context, ...args: unknown[]) => unknown;
-	export type RankResolver = (entity: unknown) => number | undefined;
-	export type ConfigOverrides = Record<string, Record<string, unknown>>;
+	/**
+	 * What actually reaches the callback: `parse` skips an argument entirely
+	 * when it is `required: false`, has no `default`, and no token was typed —
+	 * so only that combination can be undefined. Defaults are inserted raw
+	 * (no conversion), and an absent `required` behaves like required.
+	 */
+	type ArgumentRuntimeValue<T extends Argument> = T extends { required: false }
+		? T extends { default: {} }
+			? ArgumentValue<T>
+			: ArgumentValue<T> | undefined
+		: ArgumentValue<T>;
 
-	type RunArgs<T extends readonly Argument[]> = {
-		[K in keyof T]: ArgumentValue<T[K]>;
+	export type Args = ReadonlyArray<unknown>;
+
+	/** Blocks inference from this position so the branded name alone determines the tuple. */
+	type NoInfer<T> = [T][T extends unknown ? 0 : never];
+
+	/**
+	 * A server implementation name whose argument tuple was captured from the
+	 * `args` schema of the `define(...)` call that produced it. Passing one to
+	 * `implement(...)` types the callback parameters automatically.
+	 * At runtime this is a plain string.
+	 */
+	export type ServerName<A extends Args = Args> = string & { readonly __args: A };
+
+	export type Run<A extends Args = Args> = (context: Context, ...args: A) => unknown;
+
+	/** Built-in rank names ship with Konsole; custom ones can be defined via `Ranks.define`. */
+	export type RankName =
+		| "player"
+		| "helper"
+		| "trial"
+		| "lowmod"
+		| "moderator"
+		| "mod"
+		| "admin"
+		| "administrator"
+		| "creator"
+		| "owner"
+		| (string & {});
+
+	/** Anything rank lookups accept: a Player instance or a tonumber-able user id. */
+	export type RankEntity = Player | number | string | undefined;
+
+	export type RankResolver = (entity: RankEntity) => number | undefined;
+
+	export interface Rank {
+		id: number;
+		name: string;
+		aliases: string[];
+		builtin?: boolean;
+	}
+
+	export interface RanksModule {
+		readonly define: (id: number, name: string, aliases?: string[]) => Rank;
+		readonly resolve: (value: number | RankName) => number | undefined;
+		readonly label: (id: number) => string;
+		readonly list: () => Rank[];
+		readonly set: (userId: number | string, rank: number | RankName) => number;
+		readonly bind: (fn?: RankResolver) => void;
+		readonly get: (entity: RankEntity) => number;
+		readonly allows: (entity: RankEntity, required: number | RankName) => boolean;
+	}
+
+	/**
+	 * Shared by `Konsole.implement` and `Dispatch.implement` (the former just
+	 * delegates to the latter at runtime, so both must enforce the schema).
+	 * A branded `ServerName` binds the callback to its schema-inferred tuple;
+	 * plain strings fall through to the loose overload, which rejects branded
+	 * names (the intersection collapses to `never`) so an annotated callback
+	 * can't bypass its schema.
+	 */
+	interface Implement {
+		<A extends Args>(name: ServerName<A>, callback: (context: Context, ...args: NoInfer<A>) => unknown): void;
+		<N extends string, T extends Args = Args>(
+			name: N & ([N] extends [ServerName] ? never : unknown),
+			callback: (context: Context, ...args: T) => unknown,
+		): void;
+	}
+
+	export interface DispatchModule {
+		readonly remoteName: string;
+		readonly definitionsRemoteName: string;
+		readonly timeout: number;
+		readonly host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
+		readonly implement: Implement;
+		readonly execute: (text: string, entity?: RankEntity) => ExecuteResult;
+	}
+
+	export interface KommandModule {
+		readonly define: (definition: Definition) => Command;
+		readonly find: (name: string) => Command | undefined;
+		readonly list: () => Command[];
+		readonly schemas: () => Record<string, Argument[]>;
+		readonly suggestions: () => string[];
+		readonly watch: (fn?: () => void) => void;
+	}
+
+	/**
+	 * Converts one typed token. Returns `[true, value]` on success or
+	 * `[false, errorMessage]` on failure.
+	 */
+	export type Converter = (token: string, caller?: Player) => LuaTuple<[boolean, unknown]>;
+
+	export interface ArgumentsModule {
+		/** Built-in converter registry (`string`, `number`, `boolean`, `player`, `players`). */
+		readonly types: Record<string, Converter>;
+		readonly tokenize: (text?: string) => string[];
+		readonly split: (text?: string) => LuaTuple<[string | undefined, string[]]>;
+		readonly parse: (
+			argDefinitions: Argument[] | undefined,
+			tokens: string[],
+			caller?: Player,
+		) => LuaTuple<[boolean, unknown]>;
+	}
+
+	export interface ChatModule {
+		readonly bindKonsoleOpen: (callback: () => void) => () => void;
+		readonly unbindKonsoleOpen: () => void;
+	}
+
+	export interface ConfigGroups {
+		panel: {
+			width: number;
+			outputWidth: number;
+			wideWidth: number;
+			maxWidth: number;
+			collapsedWidth: number;
+			addChatCollapsedWidth: number;
+			addChatHoverWidth: number;
+			height: number;
+			inputHeight: number;
+			commandHeight: number;
+			historyLineHeight: number;
+			historyChunkLines: number;
+			historyMaxHeight: number;
+			viewportTopInset: number;
+			hintHeight: number;
+			suggestionHeight: number;
+			suggestionGap: number;
+			suggestionRadius: number;
+			maxSuggestions: number;
+			outputRadius: number;
+			displayOrder: number;
+			shadowAssetId: string;
+			arrowAssetId: string;
+			addChatAssetId: string;
+			stackGap: number;
+		};
+		color: {
+			panel: Color3;
+			inputText: Color3;
+			promptText: Color3;
+			suggPanel: Color3;
+			suggText: Color3;
+			suggMatch: string;
+			suggSub: string;
+			hintGhost: Color3;
+			successRich: string;
+			successText: Color3;
+			errorRich: string;
+			errorText: Color3;
+			warnRich: string;
+			warnText: Color3;
+			mutedRich: string;
+			mutedText: Color3;
+			shadowColor: Color3;
+		};
+		motion: {
+			expandSmoothTime: number;
+			openSmoothTime: number;
+			openSlideOffset: number;
+			outputSmoothTime: number;
+			listSmoothTime: number;
+			textFadeTime: number;
+			textSlideOffset: number;
+			itemSlideSmoothTime: number;
+			collapseSmoothTime: number;
+			exitFadeTime: number;
+			hintFadeTime: number;
+			hintSlideTime: number;
+		};
+		layout: {
+			paddingX: number;
+			paddingY: number;
+			promptSize: number;
+			textSize: number;
+			suggTextSize: number;
+			hintTextSize: number;
+			hintOffsetY: number;
+			itemGap: number;
+		};
+		transparency: {
+			panel: number;
+			suggPanel: number;
+			shadow: number;
+			arrow: number;
+			text: number;
+			suggText: number;
+			dimText: number;
+		};
+		input: {
+			activationKeys: Enum.KeyCode[];
+			activationPriority: number;
+			forceclose: boolean;
+			command: string;
+			alias: string;
+		};
+		font: {
+			body: Enum.Font;
+			title: Enum.Font;
+			mono: Enum.Font;
+		};
+		commands: {
+			defaultLimit: number;
+			aliases: Record<string, string>;
+		};
+	}
+
+	export type ConfigOverrides = {
+		[K in keyof ConfigGroups]?: Partial<ConfigGroups[K]>;
 	};
 
-	export interface Definition<T extends readonly Argument[] = readonly Argument[]> {
+	export interface ConfigModule {
+		readonly groups: ConfigGroups;
+		readonly merge: (options?: ConfigOverrides) => ConfigGroups;
+	}
+
+	export interface RenderModule {
+		readonly Result: ResultApi;
+		readonly Formatter: unknown;
+		readonly Text: unknown;
+		readonly config: (options?: ConfigOverrides) => ConfigGroups;
+		readonly new: (options?: ConfigOverrides) => Client;
+	}
+
+	/**
+	 * When the schema is a fixed tuple (the usual inline `define` call), each
+	 * run argument gets its exact type. A widened `Argument[]` schema carries
+	 * no per-position info, so the args fall back to `any` — the runtime still
+	 * passes whatever was parsed.
+	 */
+	type RunArgs<T extends readonly Argument[]> = number extends (T & { length: number })["length"]
+		? ReadonlyArray<any>
+		: { [K in keyof T]: ArgumentRuntimeValue<T[K]> };
+
+	export interface Definition<
+		T extends readonly Argument[] = readonly Argument[],
+		S extends string | undefined = string | undefined,
+	> {
 		name: string;
-		rank?: number | string;
+		rank?: number | RankName;
 		aliases?: string[];
-		args?: T;
+		args?: T & readonly Argument[];
 		description?: string;
 		cooldown?: number;
-		server?: string;
+		server?: S;
 		run?: (context: Context, ...args: RunArgs<T>) => unknown;
 	}
 
-	export interface Command {
+	export interface Command<A extends Args = Args, S extends string | undefined = string | undefined> {
 		name: string;
 		rank: number;
 		aliases: string[];
 		args: Argument[];
 		description: string;
 		cooldown: number;
-		server?: string;
-		run?: Run;
+		server: S extends string ? ServerName<A> : undefined;
+		run?: Run<A>;
 	}
 
 	export interface Context {
 		entity?: Player;
 		kommand: Command;
 		text: string;
-		dispatch: unknown;
-		ranks: unknown;
-		run: (text: unknown) => unknown;
+		dispatch: DispatchModule;
+		ranks: RanksModule;
+		run: (text: string) => ExecuteResult;
 		reply: (message?: unknown) => Outcome;
 		err: (code?: unknown, message?: unknown) => Outcome;
 	}
 
+	/**
+	 * A console client returned by `Konsole.create(...)`. Its members are
+	 * colon-methods on the Luau side, so they are declared as methods here —
+	 * roblox-ts emits `client:show()` style calls for them.
+	 */
 	export interface Client {
+		/**
+		 * Nominal marker: only values returned by `create(...)`/`Render.new(...)`
+		 * are Clients. Without it the dot-call `Api` is structurally assignable
+		 * to `Client`, and roblox-ts would emit colon calls (`c:setEnabled(true)`)
+		 * against dot functions, shifting every argument by one at runtime.
+		 */
+		readonly _nominal_Client: unique symbol;
+		bindRun(callback: (text: string) => unknown): void;
+		clear(): void;
+		destroy(): void;
+		focus(): void;
+		getCursorTarget(): Instance | undefined;
+		hide(): void;
+		setActivationKeys(keys: Enum.KeyCode[]): void;
+		setActivationUnlocksMouse(enabled: boolean): void;
+		setEnabled(enabled: boolean): void;
+		setMouseUnlockDriver(getFn?: () => boolean, setFn?: (enabled: boolean) => void): void;
+		setSchemas(map: Record<string, Argument[]>): void;
+		setSuggestions(list: string[]): void;
+		show(): void;
+		toggle(): void;
+	}
+
+	/**
+	 * The top-level API. Unlike `Client`, these are dot-functions on the Luau
+	 * side (they delegate to a lazily created default client), so they are
+	 * declared as function properties — roblox-ts emits `Konsole.show()`.
+	 */
+	export interface Api {
+		Arguments: ArgumentsModule;
+		Chat: ChatModule;
+		Config: ConfigModule;
+		Dispatch: DispatchModule;
+		Kommand: KommandModule;
+		Ranks: RanksModule;
+		Render: RenderModule;
+		Result: ResultApi;
+
+		bindRanks: (resolver?: RankResolver) => void;
+		create: (options?: ConfigOverrides) => Client;
+		define: <const T extends readonly Argument[] = readonly Argument[], S extends string | undefined = undefined>(
+			definition: Definition<T, S>,
+		) => Command<RunArgs<T>, S>;
+		excludeBuiltins: (names?: Array<string>) => void;
+		getRank: (entity: RankEntity) => number;
+		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
+		implement: Implement;
+		run: (text: string) => ExecuteResult;
+		setRank: (userId: number | string, rank: number | RankName) => number;
+
 		bindRun: (callback: (text: string) => unknown) => void;
 		clear: () => void;
 		destroy: () => void;
@@ -104,31 +443,10 @@ declare namespace Konsole {
 		setActivationUnlocksMouse: (enabled: boolean) => void;
 		setEnabled: (enabled: boolean) => void;
 		setMouseUnlockDriver: (getFn?: () => boolean, setFn?: (enabled: boolean) => void) => void;
-		setSchemas: (map: Record<string, unknown>) => void;
+		setSchemas: (map: Record<string, Argument[]>) => void;
 		setSuggestions: (list: string[]) => void;
 		show: () => void;
 		toggle: () => void;
-	}
-
-	export interface Api extends Client {
-		Arguments: unknown;
-		Chat: unknown;
-		Config: unknown;
-		Dispatch: unknown;
-		Kommand: unknown;
-		Ranks: unknown;
-		Render: unknown;
-		Result: unknown;
-		bindRanks: (resolver?: RankResolver) => void;
-		create: (options?: ConfigOverrides) => Client;
-		define: <const T extends readonly Argument[]>(
-			definition: Definition<T>,
-		) => Command;
-		getRank: (entity: unknown) => number;
-		host: (serverImplementations?: Record<string, Run>) => RemoteFunction | undefined;
-		implement: (name: string, callback: Run) => void;
-		run: (text: string) => Outcome;
-		setRank: (userId: unknown, rank: unknown) => number;
 	}
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -432,6 +432,7 @@ declare namespace Konsole {
 		getRank: (entity: RankEntity) => number;
 		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
 		implement: Implement;
+		includeBuiltins: (...names: Array<BuiltinName>) => void;
 		run: (text: string) => ExecuteResult;
 		setRank: (userId: number | string, rank: number | RankName) => number;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -102,6 +102,7 @@ declare namespace Konsole {
 		T["type"] extends "boolean" ? boolean :
 		T["type"] extends "player" ? Player :
 		T["type"] extends "players" ? Player[] :
+		T["type"] extends TypeName<infer V> ? V :
 		string;
 
 	/**
@@ -206,7 +207,16 @@ declare namespace Konsole {
 	 * Converts one typed token. Returns `[true, value]` on success or
 	 * `[false, errorMessage]` on failure.
 	 */
-	export type Converter = (token: string, caller?: Player) => LuaTuple<[boolean, unknown]>;
+	export type Converter<T = unknown> = (token: string, caller?: Player) => LuaTuple<[boolean, T]>;
+
+	/**
+	 * A custom argument type name branded with the value its converter
+	 * produces. `Konsole.registerType` returns one of these so referencing
+	 * it from `args` types the callback parameter as `T` instead of `unknown`
+	 * (same trick `ServerName` uses for `implement`). At runtime it's a
+	 * plain string.
+	 */
+	export type TypeName<T = unknown> = string & { readonly __value: T };
 
 	export interface ArgumentsModule {
 		/** Built-in converter registry (`string`, `number`, `boolean`, `player`, `players`). */
@@ -441,7 +451,7 @@ declare namespace Konsole {
 		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
 		implement: Implement;
 		includeBuiltins: (...names: Array<BuiltinName>) => void;
-		registerType: (name: string, converter: Converter) => void;
+		registerType: <T = unknown>(name: string, converter: Converter<T>) => TypeName<T>;
 		run: (text: string) => ExecuteResult;
 		setRank: (userId: number | string, rank: number | RankName) => number;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,6 +4,8 @@ declare namespace Konsole {
 
 	type BooleanArgument = `${boolean}` | "yes" | "no" | "on" | "off" | "1" | "0";
 
+	export type BuiltinName = "bring" | "clear" | "close" | "ranks" | "unban" | "cmds" | "kick" | "kill" | "ban" | "tp";
+
 	export type Argument =
 		| {
 				name?: string;
@@ -426,7 +428,7 @@ declare namespace Konsole {
 		define: <const T extends readonly Argument[] = readonly Argument[], S extends string | undefined = undefined>(
 			definition: Definition<T, S>,
 		) => Command<RunArgs<T>, S>;
-		excludeBuiltins: (names?: Array<string>) => void;
+		excludeBuiltins: (names?: Array<BuiltinName>) => void;
 		getRank: (entity: RankEntity) => number;
 		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
 		implement: Implement;


### PR DESCRIPTION
## Summary
- Full typings rewrite: typed API surface, `implement` args inferred from `define` schemas, generic `registerType<T>` returns a branded `TypeName<T>` so custom argument callbacks type as `T` instead of `unknown` (supersedes #2)
- `Konsole.registerType(name, converter)` — register custom argument types usable in `args = { { type = name } }`, converter shape matches builtins `(token, caller) -> (ok, value)`
- `Konsole.excludeBuiltins(...names)` / `Konsole.excludeAllBuiltins()` / `Konsole.includeBuiltins(...names)` — opt individual builtins in/out before Konsole is used; `cmds`/`clear` always stay registered
- `BuiltinName` union typed in both Luau and `.d.ts` instead of bare `string`
- `Argument.type` now a real literal union (`BuiltinArgumentType | string`) instead of untyped `string?`
- Pluggable codec for definitions replication
- `clr` added back as a `clear` alias
- README fully re-audited and brought up to date

## Test plan
- [x] `luau-lsp analyze` shows zero new error categories beyond documented pre-existing baseline
- [x] Verified `registerType`/`Arguments.register` reject wrong argument types via scratch Luau test
- [x] Verified `BuiltinArgumentType` union preserves literal checking despite fallback `string` member
- [x] Verified generic `registerType<T>` propagates `T` through `implement`'s callback param in a real consumer project (`tsc --noEmit`), including a deliberate type-mismatch check
- [x] Consumer project (`anime-realms`) migrated to all new APIs (`excludeAllBuiltins`, `Konsole.Result.status`, etc.)

Closes #2 (superseded by this PR).