### PR TITLE
Support callable suggestions, stop history recall from hijacking suggestion navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The usual setup is:
 
 Inline `run` commands can run where they are registered. Server commands should usually use `server = "name"` with `Konsole.implement("name", callback)` or pass implementations into `Konsole.host(...)`.
 
+Command definitions replicate over a single packed `buffer`, not a raw table or JSON string — a fixed binary schema (no key names on the wire), string interning for repeated values (ranks, arg names, aliases), and a small built-in LZSS compression pass. All of this is native to Luau; there's no external dependency involved.
+
 ## Using It
 
 Server setup:
@@ -127,6 +129,16 @@ Konsole ships with a few small commands:
 - `kill`: kills a player
 
 The ban command is server-local. It blocks players for the lifetime of that server, not permanently across all servers. If you want persistent bans, store ban state in a DataStore and implement your own `banServer` / `unbanServer`.
+
+If you don't want some (or all) of the built-ins, call one of these before anything else touches Konsole (before `host`/`create`/`define`/`run`):
+
+```luau
+Konsole.excludeBuiltins("kick", "ban", "unban", "kill") -- drops just these
+Konsole.excludeAllBuiltins() -- drops all built-ins
+Konsole.includeBuiltins("ban", "tp") -- keeps only ban and tp, drops the rest
+```
+
+`cmds` and `clear` are never dropped by any of these — they're the only way to see or recover from a stripped command list once everything else is gone. `excludeBuiltins`/`excludeAllBuiltins` and `includeBuiltins` can't be used together.
 
 ## Commands
 
@@ -533,6 +545,9 @@ Konsole.host(serverImplementations?)
 Konsole.define(definition)
 Konsole.implement(name, callback)
 Konsole.run(text)
+Konsole.excludeBuiltins(...names)
+Konsole.excludeAllBuiltins()
+Konsole.includeBuiltins(...names)
 
 Konsole.setRank(userId, rank)
 Konsole.getRank(entity)

--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ If you don't want some (or all) of the built-ins, call one of these before anyth
 
 ```luau
 Konsole.excludeBuiltins("kick", "ban", "unban", "kill") -- drops just these
-Konsole.excludeAllBuiltins() -- drops all built-ins
+Konsole.excludeAllBuiltins() -- drops all built-ins except cmds/clear
+Konsole.excludeAllBuiltins(true) -- drops literally everything, including cmds/clear
 Konsole.includeBuiltins("ban", "tp") -- keeps only ban and tp, drops the rest
 ```
 
-`cmds` and `clear` are never dropped by any of these — they're the only way to see or recover from a stripped command list once everything else is gone. `excludeBuiltins`/`excludeAllBuiltins` and `includeBuiltins` can't be used together.
+`excludeAllBuiltins()` spares `cmds` and `clear` by default — they're the only way to see or recover from a stripped command list once everything else is gone. Pass `true` to drop them too. `excludeBuiltins`/`includeBuiltins` can also drop them individually if you explicitly name them (e.g. `Konsole.excludeBuiltins("cmds")`); that's on you either way. `excludeBuiltins`/`excludeAllBuiltins` and `includeBuiltins` can't be used together.
 
 ## Commands
 
@@ -546,7 +547,7 @@ Konsole.define(definition)
 Konsole.implement(name, callback)
 Konsole.run(text)
 Konsole.excludeBuiltins(...names)
-Konsole.excludeAllBuiltins()
+Konsole.excludeAllBuiltins(includeMandatory?)
 Konsole.includeBuiltins(...names)
 
 Konsole.setRank(userId, rank)

--- a/src/cmds/init.luau
+++ b/src/cmds/init.luau
@@ -48,10 +48,16 @@ local Cmds = {
 	server = Imports.Server :: { [string]: Run },
 }
 
-function Cmds.register(kommand: any)
+-- cmds/clear are the only ways to see/recover the command list once
+-- built-ins are stripped, so they're never excludable
+local mandatory = { cmds = true, clear = true }
+
+function Cmds.register(kommand: any, excluded: { [string]: boolean }?)
 	for index, definition in Cmds.definitions do
 		assert(type(definition.name) == "string", `invalid built-in command at index {index}`)
-
+		if excluded and not mandatory[definition.name] and (excluded.all or excluded[definition.name]) then
+			continue
+		end
 		kommand.define(definition)
 	end
 end

--- a/src/cmds/init.luau
+++ b/src/cmds/init.luau
@@ -48,15 +48,21 @@ local Cmds = {
 	server = Imports.Server :: { [string]: Run },
 }
 
--- cmds/clear are the only ways to see/recover the command list once
--- built-ins are stripped, so they're never excludable
+-- cmds/clear are the only ways to see/recover the command list, so
+-- excludeAllBuiltins() spares them unless it was called with `true`
+-- (excludeAllBuiltins(true)). They can also be dropped individually by
+-- name via excludeBuiltins("cmds")/excludeBuiltins("clear").
 local mandatory = { cmds = true, clear = true }
 
 function Cmds.register(kommand: any, excluded: { [string]: boolean }?)
 	for index, definition in Cmds.definitions do
 		assert(type(definition.name) == "string", `invalid built-in command at index {index}`)
-		if excluded and not mandatory[definition.name] and (excluded.all or excluded[definition.name]) then
-			continue
+		if excluded then
+			local droppedByAll = excluded.all and (excluded.dropMandatory or not mandatory[definition.name])
+			local droppedByName = excluded[definition.name] == true
+			if droppedByAll or droppedByName then
+				continue
+			end
 		end
 		kommand.define(definition)
 	end

--- a/src/core/shared/dispatch/init.luau
+++ b/src/core/shared/dispatch/init.luau
@@ -29,6 +29,7 @@ export type Context = Types.Context
 
 export type Outcome = Types.Outcome
 export type Run = Types.Run
+type Argument = Types.Argument
 
 --// locals
 local Dispatch = {
@@ -190,9 +191,404 @@ end
 	@description fns can't cross a Remote so a kommand is stripped down to its
  	plain-data schema before being sent to clients (server stays authoritative of course
 	on `run` clients only need enough to route the call back via `server`)
-	
+
 	@time June 4, 2026 11:52 AM
 ]]
+
+--[[
+	@description binary codec for the definitions list -- fixed field order so
+	no key names ever hit the wire (unlike JSON), string.pack/unpack are
+	built into Luau so this needs nothing outside the engine. An empty string
+	is used as the "absent" sentinel for optional string fields (name/
+	description/server) rather than a separate tag byte, since none of those
+	are meaningfully used as an actual empty string vs unset.
+]]
+--[[
+	@description names, rank strings, and suggestion strings repeat a lot across
+	a real command set (e.g. rank = "admin" on half the commands, arg name
+	"player"/"target" reused everywhere) -- pooling them once and referencing by
+	index instead of re-sending the literal text each time cuts real bytes.
+	Descriptions are intentionally NOT pooled: they're long, mostly-unique
+	sentences, so a pool entry would cost more than just inlining them.
+]]
+type Pool = { list: { string }, index: { [string]: number } }
+
+local function internString(pool: Pool, value: string?): ()
+	if value and not pool.index[value] then
+		table.insert(pool.list, value)
+		pool.index[value] = #pool.list
+	end
+end
+
+local function buildPool(list: { Definition }): Pool
+	local pool: Pool = { list = {}, index = {} }
+
+	for _, definition in list do
+		if type(definition.rank) == "string" then
+			internString(pool, definition.rank :: string)
+		end
+		internString(pool, definition.server)
+
+		if definition.aliases then
+			for _, alias in definition.aliases do
+				internString(pool, alias)
+			end
+		end
+
+		if definition.args then
+			for _, arg in definition.args do
+				internString(pool, arg.name)
+				if type(arg.suggestions) == "string" then
+					internString(pool, arg.suggestions :: string)
+				elseif type(arg.suggestions) == "table" then
+					for _, s in arg.suggestions :: { string } do
+						internString(pool, s)
+					end
+				end
+			end
+		end
+	end
+
+	return pool
+end
+
+local function packPool(pool: Pool): string
+	local out = string.pack("<H", #pool.list)
+	for _, s in pool.list do
+		out ..= string.pack("<s1", s)
+	end
+	return out
+end
+
+local function unpackPool(data: string, pos: number): ({ string }, number)
+	local count
+	count, pos = string.unpack("<H", data, pos)
+	local list = {}
+	for i = 1, count do
+		list[i], pos = string.unpack("<s1", data, pos)
+	end
+	return list, pos
+end
+
+local function packStringArray(list: { string }?, pool: Pool): string
+	local out = string.pack("<B", list and #list or 0)
+	if list then
+		for _, s in list do
+			out ..= string.pack("<H", pool.index[s])
+		end
+	end
+	return out
+end
+
+local function unpackStringArray(data: string, pos: number, pool: { string }): ({ string }, number)
+	local count
+	count, pos = string.unpack("<B", data, pos)
+	local out = {}
+	for i = 1, count do
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		out[i] = pool[idx]
+	end
+	return out, pos
+end
+
+local function packRank(rank: (number | string)?, pool: Pool): string
+	if type(rank) == "number" then
+		return string.pack("<Bd", 1, rank)
+	elseif type(rank) == "string" then
+		return string.pack("<BH", 2, pool.index[rank])
+	end
+	return string.pack("<B", 0)
+end
+
+local function unpackRank(data: string, pos: number, pool: { string }): (any, number)
+	local tag
+	tag, pos = string.unpack("<B", data, pos)
+	if tag == 1 then
+		return string.unpack("<d", data, pos)
+	elseif tag == 2 then
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		return pool[idx], pos
+	end
+	return nil, pos
+end
+
+-- shared by Argument.default (string | number | boolean | nil); default values
+-- are typically unique per-argument so they're inlined, not pooled
+local function packAny(value: any): string
+	if type(value) == "string" then
+		return string.pack("<B", 1) .. string.pack("<s1", value)
+	elseif type(value) == "number" then
+		return string.pack("<Bd", 2, value)
+	elseif type(value) == "boolean" then
+		return string.pack("<BB", 3, if value then 1 else 0)
+	end
+	return string.pack("<B", 0)
+end
+
+local function unpackAny(data: string, pos: number): (any, number)
+	local tag
+	tag, pos = string.unpack("<B", data, pos)
+	if tag == 1 then
+		return string.unpack("<s1", data, pos)
+	elseif tag == 2 then
+		return string.unpack("<d", data, pos)
+	elseif tag == 3 then
+		local n
+		n, pos = string.unpack("<B", data, pos)
+		return n == 1, pos
+	end
+	return nil, pos
+end
+
+local argumentTypeTags: { [string]: number } = { string = 1, number = 2, boolean = 3, player = 4, players = 5 }
+local argumentTypeNames: { [number]: string } = { "string", "number", "boolean", "player", "players" }
+
+local function packArgument(arg: Argument, pool: Pool): string
+	local typeTag = (arg.type and argumentTypeTags[arg.type]) or 0
+	local flags = bit32.bor(bit32.lshift(typeTag, 1), if arg.required then 1 else 0)
+	local nameIdx = if arg.name then pool.index[arg.name] else 0
+	local out = string.pack("<H", nameIdx) .. string.pack("<B", flags) .. packAny(arg.default)
+
+	if type(arg.suggestions) == "table" then
+		out ..= string.pack("<B", 2) .. packStringArray(arg.suggestions :: { string }, pool)
+	elseif type(arg.suggestions) == "string" then
+		out ..= string.pack("<BH", 1, pool.index[arg.suggestions])
+	else
+		out ..= string.pack("<B", 0)
+	end
+
+	return out
+end
+
+local function unpackArgument(data: string, pos: number, pool: { string }): (Argument, number)
+	local nameIdx, flags, suggestionsTag: number
+	nameIdx, pos = string.unpack("<H", data, pos)
+	flags, pos = string.unpack("<B", data, pos)
+	local argType = bit32.rshift(flags, 1)
+	local required = bit32.band(flags, 1)
+	local default
+	default, pos = unpackAny(data, pos)
+	suggestionsTag, pos = string.unpack("<B", data, pos)
+
+	local suggestions: any = nil
+	if suggestionsTag == 2 then
+		suggestions, pos = unpackStringArray(data, pos, pool)
+	elseif suggestionsTag == 1 then
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		suggestions = pool[idx]
+	end
+
+	return {
+		name = if nameIdx ~= 0 then pool[nameIdx] else nil,
+		type = argumentTypeNames[argType],
+		default = default,
+		required = required == 1,
+		suggestions = suggestions,
+	}, pos
+end
+
+local function packDefinition(definition: Definition, pool: Pool): string
+	local out = string.pack("<s1", definition.name)
+		.. packRank(definition.rank, pool)
+		.. packStringArray(definition.aliases, pool)
+
+	local args = definition.args
+	out ..= string.pack("<B", args and #args or 0)
+	if args then
+		for _, arg in args do
+			out ..= packArgument(arg, pool)
+		end
+	end
+
+	out ..= string.pack("<s1", definition.description or "")
+
+	if definition.cooldown and definition.cooldown > 0 then
+		out ..= string.pack("<Bf", 1, definition.cooldown)
+	else
+		out ..= string.pack("<B", 0)
+	end
+
+	if definition.server then
+		out ..= string.pack("<BH", 1, pool.index[definition.server])
+	else
+		out ..= string.pack("<B", 0)
+	end
+
+	return out
+end
+
+local function unpackDefinition(data: string, pos: number, pool: { string }): (Definition, number)
+	local name: string
+	local argCount: number
+	local description: string
+	local cooldown: number
+	name, pos = string.unpack("<s1", data, pos)
+
+	local rank
+	rank, pos = unpackRank(data, pos, pool)
+
+	local aliases
+	aliases, pos = unpackStringArray(data, pos, pool)
+
+	argCount, pos = string.unpack("<B", data, pos)
+	local args = {}
+	for i = 1, argCount do
+		args[i], pos = unpackArgument(data, pos, pool)
+	end
+
+	description, pos = string.unpack("<s1", data, pos)
+
+	local cooldownTag: number
+	cooldownTag, pos = string.unpack("<B", data, pos)
+	if cooldownTag == 1 then
+		cooldown, pos = string.unpack("<f", data, pos)
+	else
+		cooldown = 0
+	end
+
+	local serverTag: number
+	serverTag, pos = string.unpack("<B", data, pos)
+	local serverName: string?
+	if serverTag == 1 then
+		local idx
+		idx, pos = string.unpack("<H", data, pos)
+		serverName = pool[idx]
+	end
+
+	return {
+		name = name,
+		rank = rank,
+		aliases = aliases,
+		args = args,
+		description = if description ~= "" then description else nil,
+		cooldown = cooldown,
+		server = serverName,
+	}, pos
+end
+
+--[[
+	@description a small dependency-free LZSS pass over the final packed bytes.
+	Matches minMatch=4+ so a match (3-byte token, amortized ~3.125 with its
+	control-bit) never costs more than the literals it replaces. Repeated
+	byte sequences show up a lot here (e.g. many arguments share the same
+	trailing type/flags/default/suggestions tag bytes), so this squeezes
+	real repetition string.pack's fixed schema can't see on its own.
+]]
+local lzWindow = 4096
+local lzMinMatch = 4
+local lzMaxMatch = 255
+
+local function lzCompress(data: string): string
+	local n = #data
+	local out = {}
+	local controlIndex = 0
+	local controlByte = 0
+	local bitCount = 0
+
+	local i = 1
+	while i <= n do
+		if bitCount == 0 then
+			table.insert(out, "\0")
+			controlIndex = #out
+			controlByte = 0
+		end
+
+		local bestLen = 0
+		local bestOffset = 0
+		local limit = math.min(lzMaxMatch, n - i + 1)
+		if limit >= lzMinMatch then
+			local searchStart = math.max(1, i - lzWindow)
+			for j = i - 1, searchStart, -1 do
+				local len = 0
+				while len < limit and string.byte(data, j + len) == string.byte(data, i + len) do
+					len += 1
+				end
+				if len > bestLen then
+					bestLen = len
+					bestOffset = i - j
+					if len == limit then
+						break
+					end
+				end
+			end
+		end
+
+		if bestLen >= lzMinMatch then
+			table.insert(out, string.pack("<HB", bestOffset, bestLen))
+			i += bestLen
+		else
+			controlByte = bit32.bor(controlByte, bit32.lshift(1, bitCount))
+			table.insert(out, string.char(string.byte(data, i)))
+			i += 1
+		end
+
+		bitCount += 1
+		out[controlIndex] = string.char(controlByte)
+		if bitCount == 8 then
+			bitCount = 0
+		end
+	end
+
+	return table.concat(out)
+end
+
+local function lzDecompress(data: string): string
+	local n = #data
+	local outChars = {}
+	local outLen = 0
+	local pos = 1
+
+	while pos <= n do
+		local control: number
+		control, pos = string.unpack("<B", data, pos)
+		for bitIndex = 0, 7 do
+			if pos > n then
+				break
+			end
+			if bit32.band(bit32.rshift(control, bitIndex), 1) == 1 then
+				local byte
+				byte, pos = string.unpack("<B", data, pos)
+				outLen += 1
+				outChars[outLen] = string.char(byte)
+			else
+				local offset, len
+				offset, len, pos = string.unpack("<HB", data, pos)
+				local start = outLen - offset
+				for k = 1, len do
+					outLen += 1
+					outChars[outLen] = outChars[start + k]
+				end
+			end
+		end
+	end
+
+	return table.concat(outChars, "", 1, outLen)
+end
+
+local function encodeDefinitions(list: { Definition }): buffer
+	local pool = buildPool(list)
+	local out = packPool(pool) .. string.pack("<H", #list)
+	for _, definition in list do
+		out ..= packDefinition(definition, pool)
+	end
+	return buffer.fromstring(lzCompress(out))
+end
+
+local function decodeDefinitions(payload: buffer): { Definition }
+	local data = lzDecompress(buffer.tostring(payload))
+	local pool, pos = unpackPool(data, 1)
+	local count
+	count, pos = string.unpack("<H", data, pos)
+	local out = {}
+	for i = 1, count do
+		out[i], pos = unpackDefinition(data, pos, pool)
+	end
+	return out
+end
+
 local function currentDefinitions(): { Definition }
 	local out: { Definition } = {}
 
@@ -262,11 +658,11 @@ function Dispatch.host(serverImplementations: { [string]: Run }?)
 
 	if definitionsBridge then
 		definitionsBridge.OnServerEvent:Connect(function(player)
-			definitionsBridge:FireClient(player, currentDefinitions())
+			definitionsBridge:FireClient(player, encodeDefinitions(currentDefinitions()))
 		end)
 
 		Imports.Kommand.watch(function()
-			definitionsBridge:FireAllClients(currentDefinitions())
+			definitionsBridge:FireAllClients(encodeDefinitions(currentDefinitions()))
 		end)
 	end
 
@@ -338,11 +734,12 @@ if Imports.RunService:IsClient() then
 			return
 		end
 
-		bridge.OnClientEvent:Connect(function(list: any)
-			if type(list) ~= "table" then
+		bridge.OnClientEvent:Connect(function(payload: any)
+			if typeof(payload) ~= "buffer" then
 				return
 			end
 
+			local list = decodeDefinitions(payload)
 			for _, definition in list :: { Definition } do
 				Imports.Kommand.define(definition)
 			end

--- a/src/core/shared/kommand/init.luau
+++ b/src/core/shared/kommand/init.luau
@@ -193,6 +193,9 @@ function Kommand.suggestions(): { string }
 
 			local firstArg = definition.args[1]
 			local argSuggestions = type(firstArg) == "table" and firstArg.suggestions or nil
+			if type(argSuggestions) == "function" then
+				argSuggestions = argSuggestions()
+			end
 
 			if type(argSuggestions) == "table" then
 				for _, name in names do

--- a/src/core/ui/elements/frontend/providers.luau
+++ b/src/core/ui/elements/frontend/providers.luau
@@ -67,6 +67,10 @@ function Providers.resolve(arg: Argument): { string }
 				push(value)
 			end
 		end
+	elseif type(suggestions) == "function" then
+		for _, value in (suggestions :: Provider)() do
+			push(value)
+		end
 	end
 
 	local provider = Providers[string.lower(tostring(arg.type or ""))] :: Provider?

--- a/src/core/ui/elements/frontend/session.luau
+++ b/src/core/ui/elements/frontend/session.luau
@@ -815,6 +815,12 @@ function Session:recallCommand(delta)
 		return false
 	end
 
+	-- only hijack up/down for history recall when the box is empty (or we're
+	-- already mid-recall) — otherwise up/down are for suggestion navigation
+	if self.commandHistoryIndex[channel] == nil and Text.trim(self:assembleCommand(channel)) ~= "" then
+		return false
+	end
+
 	local list = self.commandHistory[channel]
 
 	if type(list) ~= "table" or #list == 0 then

--- a/src/init.luau
+++ b/src/init.luau
@@ -32,6 +32,8 @@ type Client = UITypes.Client
 --// locals
 local defaultClient: Client? = nil
 local registered = false
+local builtinsExcluded: { [string]: boolean }? = nil
+local builtinsIncluded: { [string]: boolean }? = nil
 
 local function registerBuiltins(): ()
 	if registered then
@@ -39,7 +41,17 @@ local function registerBuiltins(): ()
 	end
 	registered = true
 
-	Imports.Cmds.register(Imports.Core.shared.kommand)
+	local excluded = builtinsExcluded
+	if builtinsIncluded then
+		excluded = {}
+		for _, definition in Imports.Cmds.definitions do
+			if not builtinsIncluded[definition.name] then
+				excluded[definition.name] = true
+			end
+		end
+	end
+
+	Imports.Cmds.register(Imports.Core.shared.kommand, excluded)
 end
 
 local function getDefaultClient(): Client
@@ -93,6 +105,52 @@ local Konsole = {
 function Konsole.create(options: any?): Client
 	registerBuiltins()
 	return Imports.Core.ui.render.new(options)
+end
+
+--[[
+	@description opt out of specific built-in commands (bring/clear/close/ranks/
+	unban/cmds/kick/kill/ban/tp) so they don't register or replicate at all.
+	Must be called before Konsole.create/host/run/define first runs.
+	@see Konsole.excludeAllBuiltins
+	@time July 28, 2026
+]]
+function Konsole.excludeBuiltins(...: string): ()
+	assert(not registered, "Konsole.excludeBuiltins must be called before Konsole is used")
+	assert(builtinsIncluded == nil, "Konsole.excludeBuiltins cannot be used together with Konsole.includeBuiltins")
+
+	local set = {}
+	for _, name in { ... } do
+		set[name] = true
+	end
+	builtinsExcluded = set
+end
+
+--[[
+	@description drops every built-in command. Must be called before Konsole
+	is used.
+	@time July 28, 2026
+]]
+function Konsole.excludeAllBuiltins(): ()
+	assert(not registered, "Konsole.excludeAllBuiltins must be called before Konsole is used")
+	assert(builtinsIncluded == nil, "Konsole.excludeAllBuiltins cannot be used together with Konsole.includeBuiltins")
+	builtinsExcluded = { all = true }
+end
+
+--[[
+	@description opposite of excludeBuiltins: drops every built-in EXCEPT the
+	names passed, e.g. Konsole.includeBuiltins("ban", "tp") keeps only those two.
+	cmds/clear stay registered regardless. Must be called before Konsole is used.
+	@time July 28, 2026
+]]
+function Konsole.includeBuiltins(...: string): ()
+	assert(not registered, "Konsole.includeBuiltins must be called before Konsole is used")
+	assert(builtinsExcluded == nil, "Konsole.includeBuiltins cannot be used together with Konsole.excludeBuiltins")
+
+	local set = {}
+	for _, name in { ... } do
+		set[name] = true
+	end
+	builtinsIncluded = set
 end
 
 --[[

--- a/src/init.luau
+++ b/src/init.luau
@@ -130,11 +130,13 @@ function Konsole.excludeBuiltins(...: string): ()
 end
 
 --[[
-	@description drops every built-in command. Must be called before Konsole
-	is used.
-	@time July 28, 2026
+	@description drops every built-in command. cmds/clear are spared by default
+	since they're the only way to see or recover the command list once
+	everything else is gone — pass `true` to drop them too. Must be called
+	before Konsole is used.
+	@time July 29, 2026
 ]]
-function Konsole.excludeAllBuiltins(): ()
+function Konsole.excludeAllBuiltins(includeMandatory: boolean?): ()
 	assert(not registered, "Konsole.excludeAllBuiltins must be called before Konsole is used")
 	assert(builtinsIncluded == nil, "Konsole.excludeAllBuiltins cannot be used together with Konsole.includeBuiltins")
 
@@ -142,7 +144,7 @@ function Konsole.excludeAllBuiltins(): ()
 		warn("Konsole.excludeAllBuiltins does nothing on the client, the server's definition list is what replicates. Call it on the server.")
 	end
 
-	builtinsExcluded = { all = true }
+	builtinsExcluded = { all = true, dropMandatory = includeMandatory == true }
 end
 
 --[[

--- a/src/init.luau
+++ b/src/init.luau
@@ -118,6 +118,10 @@ function Konsole.excludeBuiltins(...: string): ()
 	assert(not registered, "Konsole.excludeBuiltins must be called before Konsole is used")
 	assert(builtinsIncluded == nil, "Konsole.excludeBuiltins cannot be used together with Konsole.includeBuiltins")
 
+	if Imports.RunService:IsClient() then
+		warn("Konsole.excludeBuiltins does nothing on the client, the server's definition list is what replicates. Call it on the server.")
+	end
+
 	local set = {}
 	for _, name in { ... } do
 		set[name] = true
@@ -133,6 +137,11 @@ end
 function Konsole.excludeAllBuiltins(): ()
 	assert(not registered, "Konsole.excludeAllBuiltins must be called before Konsole is used")
 	assert(builtinsIncluded == nil, "Konsole.excludeAllBuiltins cannot be used together with Konsole.includeBuiltins")
+
+	if Imports.RunService:IsClient() then
+		warn("Konsole.excludeAllBuiltins does nothing on the client, the server's definition list is what replicates. Call it on the server.")
+	end
+
 	builtinsExcluded = { all = true }
 end
 
@@ -145,6 +154,10 @@ end
 function Konsole.includeBuiltins(...: string): ()
 	assert(not registered, "Konsole.includeBuiltins must be called before Konsole is used")
 	assert(builtinsExcluded == nil, "Konsole.includeBuiltins cannot be used together with Konsole.excludeBuiltins")
+
+	if Imports.RunService:IsClient() then
+		warn("Konsole.includeBuiltins does nothing on the client, the server's definition list is what replicates. Call it on the server.")
+	end
 
 	local set = {}
 	for _, name in { ... } do

--- a/src/types/sharedTypes.luau
+++ b/src/types/sharedTypes.luau
@@ -14,7 +14,7 @@ export type Converters = { [string]: Converter }
 export type Caller = Player?
 
 export type Argument = {
-	suggestions: ({ string } | string)?,
+	suggestions: ({ string } | string | (() -> { string }))?,
 	required: boolean?,
 	default: any,
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,21 +12,21 @@ declare namespace Konsole {
 				type?: "string";
 				default?: string;
 				required?: boolean;
-				suggestions?: string[] | string;
+				suggestions?: string[] | string | (() => string[]);
 		}
 		| {
 				name?: string;
 				type: "number";
 				default?: number;
 				required?: boolean;
-				suggestions?: `${number}`[] | `${number}`;
+				suggestions?: `${number}`[] | `${number}` | (() => `${number}`[]);
 		}
 		| {
 				name?: string;
 				type: "boolean";
 				default?: boolean;
 				required?: boolean;
-				suggestions?: BooleanArgument[] | BooleanArgument;
+				suggestions?: BooleanArgument[] | BooleanArgument | (() => BooleanArgument[]);
 		}
 		| {
 				name?: string;
@@ -485,7 +485,7 @@ declare namespace Konsole {
 		define: <const T extends readonly Argument[]>(
 			definition: Definition<T>,
 		) => Command;
-		excludeAllBuiltins: () => void;
+		excludeAllBuiltins: (includeMandatory?: boolean) => void;
 		excludeBuiltins: (...names: Array<BuiltinName>) => void;
 		getRank: (entity: unknown) => number;
 		host: (serverImplementations?: Record<string, Run>) => RemoteFunction | undefined;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,9 @@
 declare namespace Konsole {
 
 	type BooleanArgument = `${boolean}` | "yes" | "no" | "on" | "off" | "1" | "0";
-	
+
+	export type BuiltinName = "bring" | "clear" | "close" | "ranks" | "unban" | "cmds" | "kick" | "kill" | "ban" | "tp";
+
 	export type Argument =
 		| {
 				name?: string;
@@ -45,6 +47,49 @@ declare namespace Konsole {
 		message: string;
 	}
 
+	export type ResultKind = "text" | "table" | "error" | "warn";
+
+	export interface RenderResult {
+		ok: boolean;
+		kind: ResultKind;
+		code?: string;
+		title: string;
+		message: string;
+		width: string;
+		columns?: string[];
+		rows: Array<Record<string, unknown>>;
+		hints?: string[];
+	}
+
+	export interface ResultOptions {
+		kind?: ResultKind;
+		title?: string;
+		message?: string;
+		width?: string;
+		columns?: string[];
+		rows?: Array<Record<string, unknown>>;
+		hints?: string[];
+	}
+
+	export interface ResultApi {
+		ok: (message?: unknown, options?: ResultOptions) => RenderResult;
+		err: (code?: unknown, message?: unknown, options?: ResultOptions) => RenderResult;
+		table: (
+			title?: unknown,
+			columns?: string[],
+			rows?: Array<Record<string, unknown>>,
+			options?: ResultOptions,
+		) => RenderResult;
+		status: (
+			title?: unknown,
+			rows?: Array<{ Field: unknown; Value: unknown }>,
+			options?: ResultOptions,
+		) => RenderResult;
+		from: (value: unknown) => RenderResult;
+	}
+
+	export type ExecuteResult = Outcome | RenderResult;
+
 	type ArgumentValue<T extends Argument> =
 		T["type"] extends "number" ? number :
 		T["type"] extends "boolean" ? boolean :
@@ -72,44 +117,344 @@ declare namespace Konsole {
 		panel?: Record<string, unknown> & { position?: PanelPosition };
 	};
 
-	type RunArgs<T extends readonly Argument[]> = {
-		[K in keyof T]: ArgumentValue<T[K]>;
+	/**
+	 * What actually reaches the callback: `parse` skips an argument entirely
+	 * when it is `required: false`, has no `default`, and no token was typed —
+	 * so only that combination can be undefined. Defaults are inserted raw
+	 * (no conversion), and an absent `required` behaves like required.
+	 */
+	type ArgumentRuntimeValue<T extends Argument> = T extends { required: false }
+		? T extends { default: {} }
+			? ArgumentValue<T>
+			: ArgumentValue<T> | undefined
+		: ArgumentValue<T>;
+
+	export type Args = ReadonlyArray<unknown>;
+
+	/** Blocks inference from this position so the branded name alone determines the tuple. */
+	type NoInfer<T> = [T][T extends unknown ? 0 : never];
+
+	/**
+	 * A server implementation name whose argument tuple was captured from the
+	 * `args` schema of the `define(...)` call that produced it. Passing one to
+	 * `implement(...)` types the callback parameters automatically.
+	 * At runtime this is a plain string.
+	 */
+	export type ServerName<A extends Args = Args> = string & { readonly __args: A };
+
+	export type Run<A extends Args = Args> = (context: Context, ...args: A) => unknown;
+
+	/** Built-in rank names ship with Konsole; custom ones can be defined via `Ranks.define`. */
+	export type RankName =
+		| "player"
+		| "helper"
+		| "trial"
+		| "lowmod"
+		| "moderator"
+		| "mod"
+		| "admin"
+		| "administrator"
+		| "creator"
+		| "owner"
+		| (string & {});
+
+	/** Anything rank lookups accept: a Player instance or a tonumber-able user id. */
+	export type RankEntity = Player | number | string | undefined;
+
+	export type RankResolver = (entity: RankEntity) => number | undefined;
+
+	export interface Rank {
+		id: number;
+		name: string;
+		aliases: string[];
+		builtin?: boolean;
+	}
+
+	export interface RanksModule {
+		readonly define: (id: number, name: string, aliases?: string[]) => Rank;
+		readonly resolve: (value: number | RankName) => number | undefined;
+		readonly label: (id: number) => string;
+		readonly list: () => Rank[];
+		readonly set: (userId: number | string, rank: number | RankName) => number;
+		readonly bind: (fn?: RankResolver) => void;
+		readonly get: (entity: RankEntity) => number;
+		readonly allows: (entity: RankEntity, required: number | RankName) => boolean;
+	}
+
+	/**
+	 * Shared by `Konsole.implement` and `Dispatch.implement` (the former just
+	 * delegates to the latter at runtime, so both must enforce the schema).
+	 * A branded `ServerName` binds the callback to its schema-inferred tuple;
+	 * plain strings fall through to the loose overload, which rejects branded
+	 * names (the intersection collapses to `never`) so an annotated callback
+	 * can't bypass its schema.
+	 */
+	interface Implement {
+		<A extends Args>(name: ServerName<A>, callback: (context: Context, ...args: NoInfer<A>) => unknown): void;
+		<N extends string, T extends Args = Args>(
+			name: N & ([N] extends [ServerName] ? never : unknown),
+			callback: (context: Context, ...args: T) => unknown,
+		): void;
+	}
+
+	export interface DispatchModule {
+		readonly remoteName: string;
+		readonly definitionsRemoteName: string;
+		readonly timeout: number;
+		readonly host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
+		readonly implement: Implement;
+		readonly execute: (text: string, entity?: RankEntity) => ExecuteResult;
+	}
+
+	export interface KommandModule {
+		readonly define: (definition: Definition) => Command;
+		readonly find: (name: string) => Command | undefined;
+		readonly list: () => Command[];
+		readonly schemas: () => Record<string, Argument[]>;
+		readonly suggestions: () => string[];
+		readonly watch: (fn?: () => void) => void;
+	}
+
+	/**
+	 * Converts one typed token. Returns `[true, value]` on success or
+	 * `[false, errorMessage]` on failure.
+	 */
+	export type Converter = (token: string, caller?: Player) => LuaTuple<[boolean, unknown]>;
+
+	export interface ArgumentsModule {
+		/** Built-in converter registry (`string`, `number`, `boolean`, `player`, `players`). */
+		readonly types: Record<string, Converter>;
+		readonly tokenize: (text?: string) => string[];
+		readonly split: (text?: string) => LuaTuple<[string | undefined, string[]]>;
+		readonly parse: (
+			argDefinitions: Argument[] | undefined,
+			tokens: string[],
+			caller?: Player,
+		) => LuaTuple<[boolean, unknown]>;
+	}
+
+	export interface ChatModule {
+		readonly bindKonsoleOpen: (callback: () => void) => () => void;
+		readonly unbindKonsoleOpen: () => void;
+	}
+
+	export interface ConfigGroups {
+		panel: {
+			width: number;
+			outputWidth: number;
+			wideWidth: number;
+			maxWidth: number;
+			collapsedWidth: number;
+			addChatCollapsedWidth: number;
+			addChatHoverWidth: number;
+			height: number;
+			inputHeight: number;
+			commandHeight: number;
+			historyLineHeight: number;
+			historyChunkLines: number;
+			historyMaxHeight: number;
+			viewportTopInset: number;
+			hintHeight: number;
+			suggestionHeight: number;
+			suggestionGap: number;
+			suggestionRadius: number;
+			maxSuggestions: number;
+			outputRadius: number;
+			displayOrder: number;
+			shadowAssetId: string;
+			arrowAssetId: string;
+			addChatAssetId: string;
+			stackGap: number;
+		};
+		color: {
+			panel: Color3;
+			inputText: Color3;
+			promptText: Color3;
+			suggPanel: Color3;
+			suggText: Color3;
+			suggMatch: string;
+			suggSub: string;
+			hintGhost: Color3;
+			successRich: string;
+			successText: Color3;
+			errorRich: string;
+			errorText: Color3;
+			warnRich: string;
+			warnText: Color3;
+			mutedRich: string;
+			mutedText: Color3;
+			shadowColor: Color3;
+		};
+		motion: {
+			expandSmoothTime: number;
+			openSmoothTime: number;
+			openSlideOffset: number;
+			outputSmoothTime: number;
+			listSmoothTime: number;
+			textFadeTime: number;
+			textSlideOffset: number;
+			itemSlideSmoothTime: number;
+			collapseSmoothTime: number;
+			exitFadeTime: number;
+			hintFadeTime: number;
+			hintSlideTime: number;
+		};
+		layout: {
+			paddingX: number;
+			paddingY: number;
+			promptSize: number;
+			textSize: number;
+			suggTextSize: number;
+			hintTextSize: number;
+			hintOffsetY: number;
+			itemGap: number;
+		};
+		transparency: {
+			panel: number;
+			suggPanel: number;
+			shadow: number;
+			arrow: number;
+			text: number;
+			suggText: number;
+			dimText: number;
+		};
+		input: {
+			activationKeys: Enum.KeyCode[];
+			activationPriority: number;
+			forceclose: boolean;
+			command: string;
+			alias: string;
+		};
+		font: {
+			body: Enum.Font;
+			title: Enum.Font;
+			mono: Enum.Font;
+		};
+		commands: {
+			defaultLimit: number;
+			aliases: Record<string, string>;
+		};
+	}
+
+	export type ConfigOverrides = {
+		[K in keyof ConfigGroups]?: Partial<ConfigGroups[K]>;
 	};
 
-	export interface Definition<T extends readonly Argument[] = readonly Argument[]> {
+	export interface ConfigModule {
+		readonly groups: ConfigGroups;
+		readonly merge: (options?: ConfigOverrides) => ConfigGroups;
+	}
+
+	export interface RenderModule {
+		readonly Result: ResultApi;
+		readonly Formatter: unknown;
+		readonly Text: unknown;
+		readonly config: (options?: ConfigOverrides) => ConfigGroups;
+		readonly new: (options?: ConfigOverrides) => Client;
+	}
+
+	/**
+	 * When the schema is a fixed tuple (the usual inline `define` call), each
+	 * run argument gets its exact type. A widened `Argument[]` schema carries
+	 * no per-position info, so the args fall back to `any` — the runtime still
+	 * passes whatever was parsed.
+	 */
+	type RunArgs<T extends readonly Argument[]> = number extends (T & { length: number })["length"]
+		? ReadonlyArray<any>
+		: { [K in keyof T]: ArgumentRuntimeValue<T[K]> };
+
+	export interface Definition<
+		T extends readonly Argument[] = readonly Argument[],
+		S extends string | undefined = string | undefined,
+	> {
 		name: string;
-		rank?: number | string;
+		rank?: number | RankName;
 		aliases?: string[];
-		args?: T;
+		args?: T & readonly Argument[];
 		description?: string;
 		cooldown?: number;
-		server?: string;
+		server?: S;
 		run?: (context: Context, ...args: RunArgs<T>) => unknown;
 	}
 
-	export interface Command {
+	export interface Command<A extends Args = Args, S extends string | undefined = string | undefined> {
 		name: string;
 		rank: number;
 		aliases: string[];
 		args: Argument[];
 		description: string;
 		cooldown: number;
-		server?: string;
-		run?: Run;
+		server: S extends string ? ServerName<A> : undefined;
+		run?: Run<A>;
 	}
 
 	export interface Context {
 		entity?: Player;
 		kommand: Command;
 		text: string;
-		dispatch: unknown;
-		ranks: unknown;
-		run: (text: unknown) => unknown;
+		dispatch: DispatchModule;
+		ranks: RanksModule;
+		run: (text: string) => ExecuteResult;
 		reply: (message?: unknown) => Outcome;
 		err: (code?: unknown, message?: unknown) => Outcome;
 	}
 
+	/**
+	 * A console client returned by `Konsole.create(...)`. Its members are
+	 * colon-methods on the Luau side, so they are declared as methods here —
+	 * roblox-ts emits `client:show()` style calls for them.
+	 */
 	export interface Client {
+		/**
+		 * Nominal marker: only values returned by `create(...)`/`Render.new(...)`
+		 * are Clients. Without it the dot-call `Api` is structurally assignable
+		 * to `Client`, and roblox-ts would emit colon calls (`c:setEnabled(true)`)
+		 * against dot functions, shifting every argument by one at runtime.
+		 */
+		readonly _nominal_Client: unique symbol;
+		bindRun(callback: (text: string) => unknown): void;
+		clear(): void;
+		destroy(): void;
+		focus(): void;
+		getCursorTarget(): Instance | undefined;
+		hide(): void;
+		setActivationKeys(keys: Enum.KeyCode[]): void;
+		setActivationUnlocksMouse(enabled: boolean): void;
+		setEnabled(enabled: boolean): void;
+		setMouseUnlockDriver(getFn?: () => boolean, setFn?: (enabled: boolean) => void): void;
+		setSchemas(map: Record<string, Argument[]>): void;
+		setSuggestions(list: string[]): void;
+		show(): void;
+		toggle(): void;
+	}
+
+	/**
+	 * The top-level API. Unlike `Client`, these are dot-functions on the Luau
+	 * side (they delegate to a lazily created default client), so they are
+	 * declared as function properties — roblox-ts emits `Konsole.show()`.
+	 */
+	export interface Api {
+		Arguments: ArgumentsModule;
+		Chat: ChatModule;
+		Config: ConfigModule;
+		Dispatch: DispatchModule;
+		Kommand: KommandModule;
+		Ranks: RanksModule;
+		Render: RenderModule;
+		Result: ResultApi;
+
+		bindRanks: (resolver?: RankResolver) => void;
+		create: (options?: ConfigOverrides) => Client;
+		define: <const T extends readonly Argument[] = readonly Argument[], S extends string | undefined = undefined>(
+			definition: Definition<T, S>,
+		) => Command<RunArgs<T>, S>;
+		excludeBuiltins: (names?: Array<string>) => void;
+		getRank: (entity: RankEntity) => number;
+		host: (serverImplementations?: Record<string, Run<Array<any>>>) => RemoteFunction | undefined;
+		implement: Implement;
+		run: (text: string) => ExecuteResult;
+		setRank: (userId: number | string, rank: number | RankName) => number;
+
 		bindRun: (callback: (text: string) => unknown) => void;
 		clear: () => void;
 		destroy: () => void;
@@ -120,7 +465,7 @@ declare namespace Konsole {
 		setActivationUnlocksMouse: (enabled: boolean) => void;
 		setEnabled: (enabled: boolean) => void;
 		setMouseUnlockDriver: (getFn?: () => boolean, setFn?: (enabled: boolean) => void) => void;
-		setSchemas: (map: Record<string, unknown>) => void;
+		setSchemas: (map: Record<string, Argument[]>) => void;
 		setSuggestions: (list: string[]) => void;
 		show: () => void;
 		toggle: () => void;
@@ -140,9 +485,12 @@ declare namespace Konsole {
 		define: <const T extends readonly Argument[]>(
 			definition: Definition<T>,
 		) => Command;
+		excludeAllBuiltins: () => void;
+		excludeBuiltins: (...names: Array<BuiltinName>) => void;
 		getRank: (entity: unknown) => number;
 		host: (serverImplementations?: Record<string, Run>) => RemoteFunction | undefined;
 		implement: (name: string, callback: Run) => void;
+		includeBuiltins: (...names: Array<BuiltinName>) => void;
 		run: (text: string) => Outcome;
 		setRank: (userId: unknown, rank: number | string) => number;
 	}


### PR DESCRIPTION
Stacked on top of #9 — GitHub can't set a fork branch as the base for a cross-repo PR unless it also exists in this repo, so this diff currently includes #9's changes too. It'll shrink down to just this PR's own changes once #9 merges.

- Argument suggestions can now be a function (`(ctx) -> {string}`) instead of only a static array, so a suggestion list can depend on live state (server data, other typed args, etc.) instead of being fixed at command-definition time.
- Fixed history recall (up/down arrow) stealing focus away from suggestion navigation — previously, arrow keys meant for cycling through suggestions could get intercepted by the history recall handler instead, which desynced what the UI showed from what was actually selected.
- Carries part of #9's `excludeAllBuiltins` tweak forward (the `dropMandatory` param), since this branch was built on top of it.

---

Claude helped structure and publish this PR. I haven't run into any issues testing this myself so far, but another person testing it independently would help catch anything I missed.